### PR TITLE
Add Semaphore Support for `cp.async` loads (Non-TMA Load Patterns)

### DIFF
--- a/include/ops/group/memory/tile/global_to_shared.cuh
+++ b/include/ops/group/memory/tile/global_to_shared.cuh
@@ -27,3 +27,12 @@ template<ducks::st::all ST, ducks::gl::all GL, ducks::coord::tile COORD=coord<ST
 __device__ static inline void load_async(ST &dst, const GL &src, const COORD &idx) {
     kittens::load_async<2, false, ST, GL, COORD, GROUP_THREADS>(dst, src, idx);
 }
+// cp.async with semaphores
+template<int axis, bool assume_aligned, ducks::st::all ST, ducks::gl::all GL, ducks::coord::tile COORD=coord<ST>>
+__device__ static inline void load_async(ST &dst, const GL &src, const COORD &idx, semaphore &bar) {
+    kittens::load_async<axis, assume_aligned, ST, GL, COORD, GROUP_THREADS>(dst, src, idx, bar);
+}
+template<ducks::st::all ST, ducks::gl::all GL, ducks::coord::tile COORD=coord<ST>> // default case
+__device__ static inline void load_async(ST &dst, const GL &src, const COORD &idx, semaphore &bar) {
+    kittens::load_async<2, false, ST, GL, COORD, GROUP_THREADS>(dst, src, idx, bar);
+}

--- a/include/ops/warp/memory/tile/complex/complex_global_to_shared.cuh
+++ b/include/ops/warp/memory/tile/complex/complex_global_to_shared.cuh
@@ -73,4 +73,13 @@ template<ducks::cst::all CST, ducks::cgl::all CGL, ducks::coord::tile COORD=coor
 __device__ static inline void load_async(CST &dst, const CGL &src, const COORD &idx) {
     load_async<2, false, CST, CGL, COORD>(dst, src, idx);
 }
+template<int axis, bool assume_aligned, ducks::cst::all CST, ducks::cgl::all CGL, ducks::coord::tile COORD=coord<CST>>
+__device__ static inline void load_async(CST &dst, const CGL &src, const COORD &idx, semaphore &bar) {
+    load_async<axis, assume_aligned, typename CST::component, typename CGL::component>(dst.real, src.real, idx, bar);
+    load_async<axis, assume_aligned, typename CST::component, typename CGL::component>(dst.imag, src.imag, idx, bar);
+}
+template<ducks::cst::all CST, ducks::cgl::all CGL, ducks::coord::tile COORD=coord<CST>>
+__device__ static inline void load_async(CST &dst, const CGL &src, const COORD &idx, semaphore &bar) {
+    load_async<2, false, CST, CGL, COORD>(dst, src, idx, bar);
+}
 }

--- a/include/ops/warp/memory/vec/global_to_shared.cuh
+++ b/include/ops/warp/memory/vec/global_to_shared.cuh
@@ -68,7 +68,7 @@ __device__ static inline void store(const GL &dst, const SV &src, const COORD &i
  * @param[in] src The source global memory array.
  * @param[in] idx The coord of the global memory array.
  */
-template<ducks::sv::all SV, ducks::gl::all GL, ducks::coord::vec COORD=coord<SV>>
+template<ducks::sv::all SV, ducks::gl::all GL, ducks::coord::vec COORD=coord<SV>, bool should_commit_group=true>
 __device__ static inline void load_async(SV &dst, const GL &src, const COORD &idx) {
     constexpr uint32_t elem_per_transfer = sizeof(float4) / sizeof(typename SV::dtype);
     constexpr uint32_t total_calls = (dst.length + WARP_THREADS*elem_per_transfer-1) / (WARP_THREADS*elem_per_transfer); // round up
@@ -85,7 +85,38 @@ __device__ static inline void load_async(SV &dst, const GL &src, const COORD &id
             );
         }
     }
-    asm volatile("cp.async.commit_group;\n" ::: "memory");
+    if constexpr (should_commit_group) {
+        asm volatile("cp.async.commit_group;\n" ::: "memory");
+    }
 }
+
+/**
+ * @brief Asynchronously loads a vector from global to shared memory. Additionally, each thread will
+ * signal the semaphore as it completes its load. For example, if you invoke load_async from a warp
+ * with a semaphore, when all threads are completed, the sempahore's completed arrivals count
+ * will be 32.
+ * 
+ * Example Usage;
+ *     semaphore bar;
+ *     init_semaphore(bar, 32, 0); // 32 threads in a warp
+ *     load_async(dst, src, idx, bar);
+ *     wait(bar, 0); // ding! memory arrived from all threads in the warp
+ *
+ * @tparam ST The type of the shared vector.
+ * @param[out] dst The destination shared memory vector.
+ * @param[in] src The source global memory array.
+ * @param[in] idx The coordinate of the vector in the global memory array.
+ * @param[in] bar The semaphore to signal.
+ */
+template<ducks::sv::all SV, ducks::gl::all GL, ducks::coord::vec COORD=coord<SV>>
+__device__ static inline void load_async(SV &dst, const GL &src, const COORD &idx, semaphore &bar) {
+    load_async<SV, GL, COORD, false>(dst, src, idx);
+    asm volatile(
+        "cp.async.mbarrier.arrive.noinc.shared::cta.b64 [%0];\n" 
+        :: "r"(static_cast<uint32_t>(__cvta_generic_to_shared(&bar)))
+        : "memory"
+    );
+}
+
 
 }

--- a/tests/unit/group/memory/tile/global_to_shared.cu
+++ b/tests/unit/group/memory/tile/global_to_shared.cu
@@ -94,19 +94,29 @@ struct group_shared_load_store {
         }
     }
 };
-template<typename T>
+
+template<typename T, bool should_use_semaphore = false>
 struct group_shared_load_store_async {
     using dtype = T;
     template<int H, int W, int NW, typename axis> using valid = std::bool_constant<
         (H%NW==0 && H*W<=64) && (!(sizeof(T) == 1) || W%2 == 0)
     >;
-    static inline const std::string test_identifier = std::is_same_v<T, kittens::bf16> ? "group_shared_loadstore_async_gmem=bf16" :
-                                                      std::is_same_v<T, kittens::half> ? "group_shared_loadstore_async_gmem=half" :
-                                                      #ifdef KITTENS_HOPPER
-                                                      std::is_same_v<T, kittens::fp8e4m3> ? "group_shared_loadstore_async_gmem=fp8e4m3" :
-                                                        std::is_same_v<T, kittens::fp8e5m2> ? "group_shared_loadstore_async_gmem=fp8e5m2" :
-                                                        #endif
-                                                                                         "group_shared_loadstore_async_gmem=float";
+    static inline const std::string test_identifier = 
+        should_use_semaphore ?
+            (std::is_same_v<T, kittens::bf16> ? "group_shared_loadstore_async_semaphore_gmem=bf16" :
+             std::is_same_v<T, kittens::half> ? "group_shared_loadstore_async_semaphore_gmem=half" :
+             #ifdef KITTENS_HOPPER
+             std::is_same_v<T, kittens::fp8e4m3> ? "group_shared_loadstore_async_semaphore_gmem=fp8e4m3" :
+             std::is_same_v<T, kittens::fp8e5m2> ? "group_shared_loadstore_async_semaphore_gmem=fp8e5m2" :
+             #endif
+             "group_shared_loadstore_async_semaphore_gmem=float") :
+            (std::is_same_v<T, kittens::bf16> ? "group_shared_loadstore_async_gmem=bf16" :
+             std::is_same_v<T, kittens::half> ? "group_shared_loadstore_async_gmem=half" :
+             #ifdef KITTENS_HOPPER
+             std::is_same_v<T, kittens::fp8e4m3> ? "group_shared_loadstore_async_gmem=fp8e4m3" :
+             std::is_same_v<T, kittens::fp8e5m2> ? "group_shared_loadstore_async_gmem=fp8e5m2" :
+             #endif
+             "group_shared_loadstore_async_gmem=float");
     template<int H, int W, int NW, gl_t GL, typename axis> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
         o_ref = i_ref; // overwrite the whole thing
     }
@@ -119,16 +129,34 @@ struct group_shared_load_store_async {
         int num_batches = axis::value==0?((int)input.batch/shared_tile.rows):(int)input.batch;
         int num_depths = axis::value==1?((int)input.depth/shared_tile.rows):(int)input.depth;
         int num_rows = axis::value==2?((int)input.rows/shared_tile.rows):(int)input.rows;
+
+        __shared__ kittens::semaphore bar;
+        int tic = 0;
+        if constexpr (should_use_semaphore) {
+            if (threadIdx.x == 0) {
+                kittens::init_semaphore(bar, G::GROUP_THREADS, 0);
+            }
+            __syncthreads();
+        }
+
         for(int i = 0; i < num_batches; i++)
             for(int j = 0; j < num_depths; j++)
                 for(int k = 0; k < num_rows; k++)
-                    for(int l = 0; l < (input.cols/shared_tile.cols); l++) {
-            G::template load_async<axis::value, false, ST, GL>(shared_tile, input, {i, j, k, l});
-            G::load_async_wait(0);
+                    for(int l = 0; l < (input.cols/shared_tile.cols); l++, tic ^= 1) {
+            if constexpr (should_use_semaphore) {
+                G::template load_async<axis::value, false, ST, GL>(shared_tile, input, {i, j, k, l}, bar);
+                kittens::wait(bar, tic);
+            } else {
+                G::template load_async<axis::value, false, ST, GL>(shared_tile, input, {i, j, k, l});
+                kittens::load_async_wait();
+            }
             G::template store<axis::value, false, ST, GL>(output, shared_tile, {i, j, k, l});
         }
     }
 };
+
+template<typename T>
+using group_shared_load_store_async_semaphore = group_shared_load_store_async<T, true>;
 
 using I0_t = std::integral_constant<int, 0>;
 using I1_t = std::integral_constant<int, 1>;
@@ -146,6 +174,9 @@ void group::memory::tile::global_to_shared::tests(test_data &results) {
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, SIZE, 2, I0_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, SIZE, 4, I0_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, 4, 12, I0_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, SIZE, 2, I0_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, SIZE, 4, I0_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, 4, 12, I0_t>::run(results);
 
     g2s_sweep_gmem_type_2d<group_shared_load_store, SIZE, SIZE, 2, I1_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store, SIZE, SIZE, 4, I1_t>::run(results);
@@ -153,6 +184,9 @@ void group::memory::tile::global_to_shared::tests(test_data &results) {
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, SIZE, 2, I1_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, SIZE, 4, I1_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, 4, 12, I1_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, SIZE, 2, I1_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, SIZE, 4, I1_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, 4, 12, I1_t>::run(results);
 
     g2s_sweep_gmem_type_2d<group_shared_load_store, SIZE, SIZE, 2, I2_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store, SIZE, SIZE, 4, I2_t>::run(results);
@@ -160,6 +194,9 @@ void group::memory::tile::global_to_shared::tests(test_data &results) {
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, SIZE, 2, I2_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, SIZE, 4, I2_t>::run(results);
     g2s_sweep_gmem_type_2d<group_shared_load_store_async, SIZE, 4, 12, I2_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, SIZE, 2, I2_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, SIZE, 4, I2_t>::run(results);
+    g2s_sweep_gmem_type_2d<group_shared_load_store_async_semaphore, SIZE, 4, 12, I2_t>::run(results);
 }
 
 #endif

--- a/tests/unit/group/memory/vec/global_to_shared.cu
+++ b/tests/unit/group/memory/vec/global_to_shared.cu
@@ -22,13 +22,18 @@ struct vec_load_store {
     }
 };
 
-template<typename T>
+template<typename T, bool should_use_semaphore=false>
 struct vec_async_load_store {
     using dtype = T;
     template<int S, int NW> using valid = std::bool_constant<S%NW==0 && S<=64>;
-    static inline const std::string test_identifier = std::is_same_v<T, kittens::bf16> ? "group_shared_vec_loadstore_async_gmem=bf16" :
-                                                      std::is_same_v<T, kittens::half> ? "group_shared_vec_loadstore_async_gmem=half" :
-                                                                                         "group_shared_vec_loadstore_async_gmem=float";
+    static inline const std::string test_identifier = 
+        should_use_semaphore ? 
+            (std::is_same_v<T, kittens::bf16> ? "group_shared_vec_loadstore_async_semaphore_gmem=bf16" :
+             std::is_same_v<T, kittens::half> ? "group_shared_vec_loadstore_async_semaphore_gmem=half" :
+                                                "group_shared_vec_loadstore_async_semaphore_gmem=float") :
+            (std::is_same_v<T, kittens::bf16> ? "group_shared_vec_loadstore_async_gmem=bf16" :
+             std::is_same_v<T, kittens::half> ? "group_shared_vec_loadstore_async_gmem=half" :
+                                                "group_shared_vec_loadstore_async_gmem=float");
     template<int S, int NW, gl_t GL> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
         o_ref = i_ref; // overwrite the whole thing
     }
@@ -37,11 +42,28 @@ struct vec_async_load_store {
         extern __shared__ kittens::alignment_dummy __shm[]; // this is the CUDA shared memory
         kittens::shared_allocator<16> al((int*)&__shm[0]); 
         kittens::col_vec<kittens::st<dtype, 16*S, 16*S>> &shared_vec = al.allocate<kittens::col_vec<kittens::st<dtype, 16*S, 16*S>>>();
-        G::load_async(shared_vec, input, {});
-        G::load_async_wait(0);
+
+        __shared__ kittens::semaphore bar;
+        if constexpr (should_use_semaphore) {
+            if (threadIdx.x == 0) {
+                kittens::init_semaphore(bar, G::GROUP_THREADS, 0);
+            }
+            __syncthreads();
+        }
+
+        if constexpr (should_use_semaphore) {
+            G::load_async(shared_vec, input, {}, bar);
+            kittens::wait(bar, 0);
+        } else {
+            G::load_async(shared_vec, input, {});
+            kittens::load_async_wait();
+        }
         G::store(output, shared_vec, {});
     }
 };
+
+template<typename T>
+using vec_async_load_store_semaphore = vec_async_load_store<T, true>;
 
 void group::memory::vec::global_to_shared::tests(test_data &results) {
     std::cout << "\n ----- Starting ops/group/memory/vec/global_to_shared tests! -----\n" << std::endl;
@@ -69,6 +91,16 @@ void group::memory::vec::global_to_shared::tests(test_data &results) {
     sweep_size_1d<vec_async_load_store<kittens::half>, SIZE, 2>::run(results);
     sweep_size_1d<vec_async_load_store<kittens::half>, SIZE, 4>::run(results);
     sweep_size_1d<vec_async_load_store<kittens::half>, SIZE, 12>::run(results);
+
+    sweep_size_1d<vec_async_load_store_semaphore<float>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<float>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<float>, SIZE, 12>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<kittens::bf16>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<kittens::bf16>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<kittens::bf16>, SIZE, 12>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<kittens::half>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<kittens::half>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_async_load_store_semaphore<kittens::half>, SIZE, 12>::run(results);
 }
 
 #endif


### PR DESCRIPTION
This PR introduces semaphore support for non-TMA `load_async` operations by leveraging the PTX instruction `cp.async.mbarrier.arrive.noinc.shared::cta.b64`. The change aims to simplify producer-consumer kernels with non-standard load patterns that cannot be completed by the TMA.

## Background and Motivation

Working with @DanFu09, I developed sparse matmul kernels that required using `cp.async` instead of TMA because of our unique memory layout. Currently, producer-consumer kernels force the producer to call `cp.async.wait_all` and manually signal the semaphore (e.g. [FFTConv kernel](https://github.com/HazyResearch/ThunderKittens/blob/main/kernels/fftconv/pc/pc.cu#L59)). Our tests show that manually waiting on a semaphore with `cp.async.wait_all` plus an explicit `arrive(bar)` is over 200 TFLOPS slower than allowing `cp.async` to automatically signal the semaphore.

_Note on Semaphores:_  
The PTX instruction `cp.async.mbarrier.arrive.noinc.shared::cta.b64` ensures that once all non-committed `cp.async` operations from the current thread finish, that thread automatically arrives at the semaphore. Until then, it can work on other tasks. For example, when `warpgroup::load_async` is called with a semaphore, the expected arrival count is `128` (32 threads per warp * 4 warps). Detailed explanations are provided in the updated library comments.

## What's New

- Non-TMA `load_async` operations can now automatically work with semaphores by accepting an optional semaphore parameter.
- Updated load strategies in 4 areas:
    - Tile - warp level
    - Tile - group level
    - Vector - warp level
    - Vector - group level
- Added tests to ensure correctness of the new operations.