### PR TITLE
40% build speedup: get torch and python include paths without subprocesses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,19 @@
 import os
 import subprocess
+import sysconfig
+import torch
 from setuptools import setup
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension, include_paths
 from config import sources, target, kernels
 target = target.lower()
 
 # Set environment variables
 thunderkittens_root = os.getenv('THUNDERKITTENS_ROOT', os.path.abspath(os.path.join(os.getcwd(), '.')))
-python_include = subprocess.check_output(['python', '-c', "import sysconfig; print(sysconfig.get_path('include'))"]).decode().strip()
-torch_include = subprocess.check_output(['python', '-c', "import torch; from torch.utils.cpp_extension import include_paths; print(' '.join(['-I' + p for p in include_paths()]))"]).decode().strip()
+python_include = sysconfig.get_path("include")
+torch_include = [f"-I{p}" + p for p in include_paths()]
 print('Thunderkittens root:', thunderkittens_root)
 print('Python include:', python_include)
-print('Torch include directories:', torch_include)
+print('Torch include directories:', " ".join(torch_include))
 
 # CUDA flags
 cuda_flags = [
@@ -31,7 +33,7 @@ cuda_flags = [
     f'-I{thunderkittens_root}/prototype',
     f'-I{python_include}',
     '-DTORCH_COMPILE'
-] + torch_include.split()
+] + torch_include
 cpp_flags = [
     '-std=c++20',
     '-O3'


### PR DESCRIPTION
Starting python and importing torch is slow. Calling python in a subprocess could potentially be useful if the python environment changes while setup.py is running, but I don't think that can actually happen.

Timing `python3 setup.py build`, before this change:
real    1m1.822s
user    1m38.202s
sys     0m9.250s

real    1m2.285s
user    1m38.653s
sys     0m9.281s

After:
real    0m58.403s
user    0m58.709s
sys     0m7.626s

real    0m58.840s
user    1m19.693s
sys     0m8.612s