### PR TITLE
Remove unnecessary device and stream syncs

### DIFF
--- a/kernels/attn/h100/h100.cu
+++ b/kernels/attn/h100/h100.cu
@@ -712,7 +712,7 @@ attention_forward(torch::Tensor q, torch::Tensor k, torch::Tensor v, bool causal
     float* l_ptr = reinterpret_cast<float*>(l_vec.data_ptr<float>());
     float* d_l   = reinterpret_cast<float*>(l_ptr);
 
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
     auto stream = at::cuda::getCurrentCUDAStream().stream(); 
 
     if (head_dim == 64) {
@@ -763,7 +763,7 @@ attention_forward(torch::Tensor q, torch::Tensor k, torch::Tensor v, bool causal
             fwd_attend_ker<64, false><<<grid, (32*NUM_WORKERS), mem_size, stream>>>(g);
         }
         CHECK_CUDA_ERROR(cudaGetLastError());
-        cudaStreamSynchronize(stream);
+        // cudaStreamSynchronize(stream);
     }
 
     if (head_dim == 128) {
@@ -815,11 +815,11 @@ attention_forward(torch::Tensor q, torch::Tensor k, torch::Tensor v, bool causal
         }
 
         CHECK_CUDA_ERROR(cudaGetLastError());
-        cudaStreamSynchronize(stream);
+        // cudaStreamSynchronize(stream);
     }
 
     return {o, l_vec};
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
 }
 
 std::vector<torch::Tensor> 
@@ -925,10 +925,10 @@ attention_backward(torch::Tensor q,
     auto mem_size = kittens::MAX_SHARED_MEMORY; 
     auto threads  = 4 * kittens::WARP_THREADS;
 
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    cudaStreamSynchronize(stream);
+    // cudaStreamSynchronize(stream);
 
     // TORCH_CHECK(seq_len % (4*kittens::TILE_DIM*4) == 0, "sequence length must be divisible by 256");
     dim3 grid_bwd(seq_len/(4*kittens::TILE_ROW_DIM<bf16>*4), qo_heads, batch);
@@ -1009,7 +1009,7 @@ attention_backward(torch::Tensor q,
         dim3 grid_bwd_2(seq_len/(4*BWD_CONSUMER_WARPGROUPS*kittens::TILE_ROW_DIM<bf16>), qo_heads, batch);
         threads = kittens::WARP_THREADS * BWD_NUM_WORKERS;
 
-        cudaDeviceSynchronize();
+        // cudaDeviceSynchronize();
 
         if (is_causal) {
             cudaFuncSetAttribute(
@@ -1041,8 +1041,8 @@ attention_backward(torch::Tensor q,
         }
 
         // CHECK_CUDA_ERROR(cudaGetLastError());
-        cudaStreamSynchronize(stream);
-        cudaDeviceSynchronize();
+        // cudaStreamSynchronize(stream);
+        // cudaDeviceSynchronize();
         // const auto kernel_end = std::chrono::high_resolution_clock::now();
         // std::cout << "Kernel Time: " << std::chrono::duration_cast<std::chrono::microseconds>(kernel_end - start).count() << "us" << std::endl;
         // std::cout << "---" << std::endl;
@@ -1125,8 +1125,8 @@ attention_backward(torch::Tensor q,
         dim3 grid_bwd_2(seq_len/(4*BWD_CONSUMER_WARPGROUPS*kittens::TILE_ROW_DIM<bf16>), qo_heads, batch);
         threads = kittens::WARP_THREADS * BWD_NUM_WORKERS;
 
-        cudaStreamSynchronize(stream);
-        cudaDeviceSynchronize(); 
+        // cudaStreamSynchronize(stream);
+        // cudaDeviceSynchronize(); 
         
         if (is_causal) {
             cudaFuncSetAttribute(
@@ -1158,12 +1158,12 @@ attention_backward(torch::Tensor q,
         }
 
         // CHECK_CUDA_ERROR(cudaGetLastError());
-        cudaStreamSynchronize(stream);
-        cudaDeviceSynchronize();
+        // cudaStreamSynchronize(stream);
+        // cudaDeviceSynchronize();
     }
 
     return {qg, kg, vg};
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
 }
 
 #else

--- a/kernels/based/lin_attn_4090.cu
+++ b/kernels/based/lin_attn_4090.cu
@@ -296,7 +296,7 @@ void dispatch_based(
 
     // launch
     unsigned long mem_size = 100000; // 4090
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
     cudaFuncSetAttribute(
         based_linear_attention,
         cudaFuncAttributeMaxDynamicSharedMemorySize,
@@ -305,7 +305,7 @@ void dispatch_based(
     dim3 grid(ATTN_H, ATTN_B);
     based_linear_attention<<<grid,NUM_THREADS,mem_size>>>(g);
     CHECK_CUDA_ERROR(cudaGetLastError());
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
 }
 
 std::tuple<torch::Tensor, torch::Tensor> based(
@@ -361,7 +361,7 @@ std::tuple<torch::Tensor, torch::Tensor> based(
 
     CHECK_CUDA_ERROR(cudaGetLastError());
     return std::make_tuple(out, kv_concat);
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
 }
 #else
 #include "harness_4090.impl"

--- a/kernels/based/lin_attn_h100.cu
+++ b/kernels/based/lin_attn_h100.cu
@@ -352,7 +352,7 @@ void dispatch_based(
 
     // launch
     unsigned long mem_size = 98000;
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
     cudaFuncSetAttribute(
         based_linear_attention,
         cudaFuncAttributeMaxDynamicSharedMemorySize,
@@ -361,7 +361,7 @@ void dispatch_based(
     dim3 grid(ATTN_H, ATTN_B);
     based_linear_attention<<<grid,NUM_THREADS,mem_size>>>(g);
     CHECK_CUDA_ERROR(cudaGetLastError());
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
 }
 
 std::tuple<torch::Tensor, torch::Tensor> based(
@@ -418,7 +418,7 @@ std::tuple<torch::Tensor, torch::Tensor> based(
 
     CHECK_CUDA_ERROR(cudaGetLastError());
     return std::make_tuple(out, kv_concat);
-    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize();
 }
 #else
 #include "harness_h100.impl"

--- a/kernels/ring_attention/tk_ring_attention.cu
+++ b/kernels/ring_attention/tk_ring_attention.cu
@@ -330,7 +330,7 @@ std::vector<torch::Tensor> ring_attention_forward(
     club.execute([&](int i) {
         cudaFuncSetAttribute(blockwise_attn_ker<64, false>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
         blockwise_attn_ker<64, false><<<grid, NUM_WORKERS * kittens::WARP_THREADS, smem, streams[i]>>>(p_G, i);
-        cudaStreamSynchronize(streams[i]);
+        // cudaStreamSynchronize(streams[i]);
         CHECK_CUDA_ERROR(cudaGetLastError());
     });
 


### PR DESCRIPTION
When reading lots of TK kernels, I see a bunch of `cudaDeviceSynchronize` and `cudaStreamSynchronize()`, even sometimes consecutively. However, they are very expensive and should not be used inside general kernel dispatch except for testing and debugging purposes.
I see the following use cases for them:
1. `cudaStreamSynchronize` can be used to time kernels during benchmarks (though cuda events will likely be more accurate)
2. Both can cause errors to be reported from the right line on the host side. There's no need to use `cudaDeviceSynchronize` for debugging, and we can add a debug flag to trigger stream sync.
Removing them can speed up significantly when porting code to general use cases.
See https://github.com/hao-ai-lab/FastVideo/pull/517
Thanks.