### PR TITLE
Zero the initial accumulator before applying `HMMA.16816`

### DIFF
--- a/kernels/matmul/educational/level_04.cu
+++ b/kernels/matmul/educational/level_04.cu
@@ -38,6 +38,7 @@ __global__ void kernel(const __grid_constant__ matmul_globals g) {
     int col = blockIdx.x; 
     int row = blockIdx.y; 
 
+    zero(C_accum);
     int num_tiles = (g.N + BLOCK_SIZE - 1) / BLOCK_SIZE;
     for (int tile = 0; tile < num_tiles; ++tile) {
         load(As, g.A, {0, 0, row, tile});


### PR DESCRIPTION
I'm not sure how that is supposed to work (maybe I'm missing something?), but without zeroing the reference check non-deterministically fails, as I would expect:
```
$ ./matmul
--------------------  M=4096 N=4096 K=4096  --------------------
...
Copied result back to host
Converted result back to float
Error at row 0 col 8: 3.64062 != 3.26331 (ref)
Error at row 0 col 9: 3.625 != 3.74322 (ref)
Error at row 0 col 10: -1.47656 != -1.60718 (ref)
Error at row 0 col 11: 3.17188 != 3.00533 (ref)
Error at row 0 col 12: 6.65625 != 6.23455 (ref)
Error at row 0 col 14: 5.8125 != 6.0381 (ref)
Error at row 0 col 24: 4.8125 != 4.45942 (ref)
Error at row 0 col 25: -5.375 != -5.60978 (ref)
Error at row 0 col 26: -3.9375 != -4.13787 (ref)
Error at row 0 col 27: -2.89062 != -2.65025 (ref)
Error at row 0 col 28: -8.8125 != -8.45518 (ref)
Error at row 0 col 40: 2.23438 != 1.85622 (ref)
Error at row 0 col 41: -1.44531 != -1.03966 (ref)
Error at row 0 col 44: -6.09375 != -5.61794 (ref)
Error at row 0 col 47: -6.4375 != -6.5418 (ref)
Error at row 0 col 56: -4.125 != -4.49885 (ref)
Error at row 0 col 57: -7.1875 != -7.41047 (ref)
Error at row 0 col 58: 1.52344 != 1.34101 (ref)
Error at row 0 col 59: -8.25 != -8.0291 (ref)
Error at row 0 col 60: -0.25 != 0.0749529 (ref)
Too many errors to show them all.
Max error: 0.581142
Error count: 5039965
Total count: 16777216
$ ./matmul
--------------------  M=4096 N=4096 K=4096  --------------------
...
Copied result back to host
Converted result back to float
Error at row 0 col 8: 3.125 != 3.26331 (ref)
Error at row 0 col 9: 3.625 != 3.74322 (ref)
Error at row 0 col 10: -1.28906 != -1.60718 (ref)
Error at row 0 col 11: 2.65625 != 3.00533 (ref)
Error at row 0 col 13: 2.28125 != 2.55398 (ref)
Error at row 0 col 15: 4.46875 != 4.82473 (ref)
Error at row 0 col 24: 4.8125 != 4.45942 (ref)
Error at row 0 col 25: -5.21875 != -5.60978 (ref)
Error at row 0 col 26: -3.95312 != -4.13787 (ref)
Error at row 0 col 28: -8.9375 != -8.45518 (ref)
Error at row 0 col 29: 2.53125 != 2.36679 (ref)
Error at row 0 col 31: -6.0625 != -6.41107 (ref)
Error at row 0 col 40: 2.125 != 1.85622 (ref)
Error at row 0 col 42: -1.39844 != -1.53621 (ref)
Error at row 0 col 43: -6.84375 != -6.60853 (ref)
Error at row 0 col 44: -5.875 != -5.61794 (ref)
Error at row 0 col 46: 10.25 != 9.84855 (ref)
Error at row 0 col 47: -6.25 != -6.5418 (ref)
Error at row 0 col 56: -4.125 != -4.49885 (ref)
Error at row 0 col 57: -7.1875 != -7.41047 (ref)
Too many errors to show them all.
Max error: 513.922
Error count: 6088746
Total count: 16777216
```

With zeroing, the result is deterministic, and matches the one from `level_05`:
```
$ ./matmul
--------------------  M=4096 N=4096 K=4096  --------------------
...
Copied result back to host
Converted result back to float
Max error: 0.0982647
Error count: 0
Total count: 16777216
```