### PR TITLE
Fix unit test Makefile bugs for A100 and 4090 results in linker failure due to cuda libraries missing

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -32,9 +32,9 @@ endif
 
 # Compiler flags based on GPU target
 ifeq ($(GPU_TARGET),4090)
-NVCCFLAGS+= -arch=sm_89 -DKITTENS_4090
+NVCCFLAGS+= -arch=sm_89 -DKITTENS_4090 -lcuda -lcudart
 else ifeq ($(GPU_TARGET),A100)
-NVCCFLAGS+= -arch=sm_80 -DKITTENS_A100
+NVCCFLAGS+= -arch=sm_80 -DKITTENS_A100 -lcuda -lcudart
 else ifeq ($(GPU_TARGET),H100)
 NVCCFLAGS+= -arch=sm_90a -DKITTENS_HOPPER -lcuda -lcudart
 endif


### PR DESCRIPTION

Signed-off-by: Chenwei Sun <chenwei.sun@intel.com>