### PR TITLE
fp8 shared vector support (e4m3/e5m2/e8m0)

### DIFF
--- a/include/common/base_types.cuh
+++ b/include/common/base_types.cuh
@@ -513,6 +513,26 @@ template<> struct convertor<fp8e8m0_4, bf16_2> {
         return __nv_fp8x4_e8m0(f4);
     }
 };
+template<> struct convertor<bf16, fp8e8m0> {
+    static __host__ __device__ inline bf16 convert(const fp8e8m0 & u) {
+        return __float2bfloat16_rn(float(u));
+    }
+};
+template<> struct convertor<fp8e8m0, bf16> {
+    static __host__ __device__ inline fp8e8m0 convert(const bf16 & u) {
+        return __nv_fp8_e8m0(__bfloat162float(u));
+    }
+};
+template<> struct convertor<half, fp8e8m0> {
+    static __host__ __device__ inline half convert(const fp8e8m0 & u) {
+        return __float2half(float(u));
+    }
+};
+template<> struct convertor<fp8e8m0, half> {
+    static __host__ __device__ inline fp8e8m0 convert(const half & u) {
+        return __nv_fp8_e8m0(__half2float(u));
+    }
+};
 // fp4e2m1
 template<> struct convertor<fp4e2m1, float> {
     static __device__ inline fp4e2m1 convert(const float & u) {
@@ -575,6 +595,26 @@ template<> struct convertor<float, fp8e4m3> {
         return float(u);
     }
 };
+template<> struct convertor<bf16, fp8e4m3> {
+    static __host__ __device__ inline bf16 convert(const fp8e4m3 & u) {
+        return __float2bfloat16_rn(float(u));
+    }
+};
+template<> struct convertor<fp8e4m3, bf16> {
+    static __host__ __device__ inline fp8e4m3 convert(const bf16 & u) {
+        return __nv_fp8_e4m3(__bfloat162float(u));
+    }
+};
+template<> struct convertor<half, fp8e4m3> {
+    static __host__ __device__ inline half convert(const fp8e4m3 & u) {
+        return __float2half(float(u));
+    }
+};
+template<> struct convertor<fp8e4m3, half> {
+    static __host__ __device__ inline fp8e4m3 convert(const half & u) {
+        return __nv_fp8_e4m3(__half2float(u));
+    }
+};
 template<> struct convertor<bf16_2, fp8e4m3_4> {
     static __host__ __device__ inline bf16_2 convert(const fp8e4m3_4 & u) {
         float4 f4 = convertor<float4, fp8e4m3_4>::convert(u);
@@ -620,6 +660,26 @@ template<> struct convertor<fp8e5m2, float> {
 template<> struct convertor<float, fp8e5m2> {
     static __host__ __device__ inline float convert(const fp8e5m2 & u) {
         return float(u);
+    }
+};
+template<> struct convertor<bf16, fp8e5m2> {
+    static __host__ __device__ inline bf16 convert(const fp8e5m2 & u) {
+        return __float2bfloat16_rn(float(u));
+    }
+};
+template<> struct convertor<fp8e5m2, bf16> {
+    static __host__ __device__ inline fp8e5m2 convert(const bf16 & u) {
+        return __nv_fp8_e5m2(__bfloat162float(u));
+    }
+};
+template<> struct convertor<half, fp8e5m2> {
+    static __host__ __device__ inline half convert(const fp8e5m2 & u) {
+        return __float2half(float(u));
+    }
+};
+template<> struct convertor<fp8e5m2, half> {
+    static __host__ __device__ inline fp8e5m2 convert(const half & u) {
+        return __nv_fp8_e5m2(__half2float(u));
     }
 };
 template<> struct convertor<bf16_2, fp8e5m2_4> {

--- a/include/types/shared/sv.cuh
+++ b/include/types/shared/sv.cuh
@@ -59,12 +59,6 @@ struct KITTENS_DEFAULT_ALIGN sv {
     static constexpr int length = _length; ///< Length in elements.
     static_assert(length % TILE_ROW_DIM<T> == 0, "Length must be divisible by the tile dimension");
     static constexpr int tiles  = length / TILE_ROW_DIM<T>; ///< Length in subtiles.'
-#if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
-    static_assert(!std::is_same_v<T2, fp8e4m3_4> && !std::is_same_v<T2, fp8e5m2_4>, "Unsupported type for fp8");
-#endif
-#if defined(KITTENS_BLACKWELL)
-    static_assert(!std::is_same_v<T2, fp8e4m3_4> && !std::is_same_v<T2, fp8e5m2_4> || !std::is_same_v<T2, fp8e8m0_4>, "Unsupported type for fp8");
-#endif
 
 #if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
     static constexpr int num_alloc_elements = ((length * sizeof(dtype) + 127) / 128) * (128 / sizeof(dtype)); // round up to the nearest 128-byte boundary

--- a/tests/group/memory/vec/global_to_shared.cu
+++ b/tests/group/memory/vec/global_to_shared.cu
@@ -43,6 +43,50 @@ struct vec_async_load_store {
     }
 };
 
+#if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
+// fp8 types use sv<T,N> directly: TILE_COL_DIM<fp8>=32 makes st<fp8,16*S,16*S> invalid for odd S
+template<typename T>
+struct vec_fp8_load_store {
+    using dtype = T;
+    template<int S, int NW> using valid = std::bool_constant<S%NW==0 && S<=64>;
+    static inline const std::string test_identifier = std::is_same_v<T, kittens::fp8e4m3> ? "group_shared_vec_loadstore_gmem=fp8e4m3" :
+                                                      std::is_same_v<T, kittens::fp8e5m2> ? "group_shared_vec_loadstore_gmem=fp8e5m2" :
+                                                                                             "group_shared_vec_loadstore_gmem=fp8e8m0";
+    template<int S, int NW, gl_t GL> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        o_ref = i_ref;
+    }
+    template<int S, int NW, gl_t GL> __device__ static void device_func(const GL &input, const GL &output) {
+        using G = kittens::group<NW>;
+        extern __shared__ kittens::alignment_dummy __shm[];
+        kittens::shared_allocator<16> al((int*)&__shm[0]);
+        kittens::sv<T, 16*S> &shared_vec = al.allocate<kittens::sv<T, 16*S>>();
+        G::load(shared_vec, input, {});
+        G::store(output, shared_vec, {});
+    }
+};
+
+template<typename T>
+struct vec_fp8_async_load_store {
+    using dtype = T;
+    template<int S, int NW> using valid = std::bool_constant<S%NW==0 && S<=64>;
+    static inline const std::string test_identifier = std::is_same_v<T, kittens::fp8e4m3> ? "group_shared_vec_loadstore_async_gmem=fp8e4m3" :
+                                                      std::is_same_v<T, kittens::fp8e5m2> ? "group_shared_vec_loadstore_async_gmem=fp8e5m2" :
+                                                                                             "group_shared_vec_loadstore_async_gmem=fp8e8m0";
+    template<int S, int NW, gl_t GL> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        o_ref = i_ref;
+    }
+    template<int S, int NW, gl_t GL> __device__ static void device_func(const GL &input, const GL &output) {
+        using G = kittens::group<NW>;
+        extern __shared__ kittens::alignment_dummy __shm[];
+        kittens::shared_allocator<16> al((int*)&__shm[0]);
+        kittens::sv<T, 16*S> &shared_vec = al.allocate<kittens::sv<T, 16*S>>();
+        G::load_async(shared_vec, input, {});
+        G::load_async_wait(0);
+        G::store(output, shared_vec, {});
+    }
+};
+#endif
+
 void group::memory::vec::global_to_shared::tests(test_data &results) {
     std::cout << " ----- Starting ops/group/memory/vec/global_to_shared tests! -----\n" << std::endl;
     constexpr int SIZE = INTENSITY_1 ? 2  :
@@ -62,7 +106,24 @@ void group::memory::vec::global_to_shared::tests(test_data &results) {
     sweep_size_1d<vec_load_store<kittens::half>, SIZE, 2>::run(results);
     sweep_size_1d<vec_load_store<kittens::half>, SIZE, 4>::run(results);
     sweep_size_1d<vec_load_store<kittens::half>, SIZE, 12>::run(results);
-                         
+#if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e4m3>, SIZE, 1>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e4m3>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e4m3>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e4m3>, SIZE, 12>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e5m2>, SIZE, 1>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e5m2>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e5m2>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e5m2>, SIZE, 12>::run(results);
+#endif
+
+#if defined(KITTENS_BLACKWELL)
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e8m0>, SIZE, 1>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e8m0>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e8m0>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_fp8_load_store<kittens::fp8e8m0>, SIZE, 12>::run(results);
+#endif
+
     sweep_size_1d<vec_async_load_store<float>, SIZE, 1>::run(results);
     sweep_size_1d<vec_async_load_store<float>, SIZE, 2>::run(results);
     sweep_size_1d<vec_async_load_store<float>, SIZE, 4>::run(results);
@@ -75,6 +136,23 @@ void group::memory::vec::global_to_shared::tests(test_data &results) {
     sweep_size_1d<vec_async_load_store<kittens::half>, SIZE, 2>::run(results);
     sweep_size_1d<vec_async_load_store<kittens::half>, SIZE, 4>::run(results);
     sweep_size_1d<vec_async_load_store<kittens::half>, SIZE, 12>::run(results);
+#if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e4m3>, SIZE, 1>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e4m3>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e4m3>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e4m3>, SIZE, 12>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e5m2>, SIZE, 1>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e5m2>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e5m2>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e5m2>, SIZE, 12>::run(results);
+#endif
+
+#if defined(KITTENS_BLACKWELL)
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e8m0>, SIZE, 1>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e8m0>, SIZE, 2>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e8m0>, SIZE, 4>::run(results);
+    sweep_size_1d<vec_fp8_async_load_store<kittens::fp8e8m0>, SIZE, 12>::run(results);
+#endif
     std::cout << std::endl;
 }
 

--- a/tests/group/shared/vec/conversions.cu
+++ b/tests/group/shared/vec/conversions.cu
@@ -20,16 +20,118 @@ struct vec_copy {
     }
 };
 
+#if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
+
+struct vec_convert_fp8e4m3 {
+    using dtype = kittens::bf16;
+    template<int S, int NW> using valid = std::bool_constant<S%NW==0 && S<=64>;
+    static inline const std::string test_identifier = "shared_vec_convert_e4m3_roundtrip";
+    template<int S, int NW, gl_t GL> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for (int i = 0; i < (int)o_ref.size(); i++)
+            o_ref[i] = float(kittens::fp8e4m3(i_ref[i]));
+    }
+    template<int S, int NW, gl_t GL> __device__ static void device_func(const GL &input, const GL &output) {
+        using G = kittens::group<NW>;
+        extern __shared__ kittens::alignment_dummy __shm[];
+        kittens::shared_allocator al((int*)&__shm[0]);
+        kittens::sv_bf<16*S>      &sv_b1  = al.allocate<kittens::sv_bf<16*S>>();
+        kittens::sv_fp8e4m3<16*S> &sv_fp8 = al.allocate<kittens::sv_fp8e4m3<16*S>>();
+        kittens::sv_bf<16*S>      &sv_b2  = al.allocate<kittens::sv_bf<16*S>>();
+        G::load(sv_b1, input, {});
+        G::sync(0);
+        G::copy(sv_fp8, sv_b1);
+        G::sync(0);
+        G::copy(sv_b2, sv_fp8);
+        G::sync(0);
+        G::store(output, sv_b2, {});
+    }
+};
+
+struct vec_convert_fp8e5m2 {
+    using dtype = kittens::bf16;
+    template<int S, int NW> using valid = std::bool_constant<S%NW==0 && S<=64>;
+    static inline const std::string test_identifier = "shared_vec_convert_e5m2_roundtrip";
+    template<int S, int NW, gl_t GL> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for (int i = 0; i < (int)o_ref.size(); i++)
+            o_ref[i] = float(kittens::fp8e5m2(i_ref[i]));
+    }
+    template<int S, int NW, gl_t GL> __device__ static void device_func(const GL &input, const GL &output) {
+        using G = kittens::group<NW>;
+        extern __shared__ kittens::alignment_dummy __shm[];
+        kittens::shared_allocator al((int*)&__shm[0]);
+        kittens::sv_bf<16*S>      &sv_b1  = al.allocate<kittens::sv_bf<16*S>>();
+        kittens::sv_fp8e5m2<16*S> &sv_fp8 = al.allocate<kittens::sv_fp8e5m2<16*S>>();
+        kittens::sv_bf<16*S>      &sv_b2  = al.allocate<kittens::sv_bf<16*S>>();
+        G::load(sv_b1, input, {});
+        G::sync(0);
+        G::copy(sv_fp8, sv_b1);
+        G::sync(0);
+        G::copy(sv_b2, sv_fp8);
+        G::sync(0);
+        G::store(output, sv_b2, {});
+    }
+};
+
+#endif // KITTENS_HOPPER || KITTENS_BLACKWELL
+
+#if defined(KITTENS_BLACKWELL)
+
+struct vec_convert_fp8e8m0 {
+    using dtype = kittens::bf16;
+    template<int S, int NW> using valid = std::bool_constant<S%NW==0 && S<=64>;
+    static inline const std::string test_identifier = "shared_vec_convert_e8m0_roundtrip";
+    template<int S, int NW, gl_t GL> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for (int i = 0; i < (int)o_ref.size(); i++)
+            o_ref[i] = float(kittens::fp8e8m0(i_ref[i]));
+    }
+    template<int S, int NW, gl_t GL> __device__ static void device_func(const GL &input, const GL &output) {
+        using G = kittens::group<NW>;
+        extern __shared__ kittens::alignment_dummy __shm[];
+        kittens::shared_allocator al((int*)&__shm[0]);
+        kittens::sv_bf<16*S>      &sv_b1  = al.allocate<kittens::sv_bf<16*S>>();
+        kittens::sv_fp8e8m0<16*S> &sv_fp8 = al.allocate<kittens::sv_fp8e8m0<16*S>>();
+        kittens::sv_bf<16*S>      &sv_b2  = al.allocate<kittens::sv_bf<16*S>>();
+        G::load(sv_b1, input, {});
+        G::sync(0);
+        G::copy(sv_fp8, sv_b1);
+        G::sync(0);
+        G::copy(sv_b2, sv_fp8);
+        G::sync(0);
+        G::store(output, sv_b2, {});
+    }
+};
+
+#endif // KITTENS_BLACKWELL
+
 void group::shared::vec::conversions::tests(test_data &results) {
     std::cout << " ----- Starting ops/group/shared/vec/conversions tests! -----\n" << std::endl;
     constexpr int SIZE = INTENSITY_1 ? 2  :
-                         INTENSITY_2 ? 4  : 
+                         INTENSITY_2 ? 4  :
                          INTENSITY_3 ? 8  :
                          INTENSITY_4 ? 16 : -1;
-                         
+
     sweep_size_1d<vec_copy, SIZE, 2>::run(results);
     sweep_size_1d<vec_copy, SIZE, 4>::run(results);
     sweep_size_1d<vec_copy, SIZE, 12>::run(results);
+
+#if defined(KITTENS_HOPPER) || defined(KITTENS_BLACKWELL)
+    sweep_size_1d<vec_convert_fp8e4m3, SIZE, 1>::run(results);
+    sweep_size_1d<vec_convert_fp8e4m3, SIZE, 2>::run(results);
+    sweep_size_1d<vec_convert_fp8e4m3, SIZE, 4>::run(results);
+    sweep_size_1d<vec_convert_fp8e4m3, SIZE, 12>::run(results);
+    sweep_size_1d<vec_convert_fp8e5m2, SIZE, 1>::run(results);
+    sweep_size_1d<vec_convert_fp8e5m2, SIZE, 2>::run(results);
+    sweep_size_1d<vec_convert_fp8e5m2, SIZE, 4>::run(results);
+    sweep_size_1d<vec_convert_fp8e5m2, SIZE, 12>::run(results);
+#endif
+
+#if defined(KITTENS_BLACKWELL)
+    sweep_size_1d<vec_convert_fp8e8m0, SIZE, 1>::run(results);
+    sweep_size_1d<vec_convert_fp8e8m0, SIZE, 2>::run(results);
+    sweep_size_1d<vec_convert_fp8e8m0, SIZE, 4>::run(results);
+    sweep_size_1d<vec_convert_fp8e8m0, SIZE, 12>::run(results);
+#endif
+
     std::cout << std::endl;
 }
 

--- a/tests/testing_commons/testing_commons.cuh
+++ b/tests/testing_commons/testing_commons.cuh
@@ -160,7 +160,11 @@ struct wrapper_1d {
             // fill in correct results on cpu
             test::template host_func<S, NUM_WORKERS, GL, args...>(i_ref, o_ref);
             // check and cleanup
-            this_result.result = validate(d_i, d_o, i_ref, o_ref, this_result.label, S*16);
+            const bool is_fp8 = this_result.label.find("fp8")  != std::string::npos ||
+                                this_result.label.find("e4m3") != std::string::npos ||
+                                this_result.label.find("e5m2") != std::string::npos ||
+                                this_result.label.find("e8m0") != std::string::npos;
+            this_result.result = validate(d_i, d_o, i_ref, o_ref, this_result.label, S*16, is_fp8 ? 0.1f : 5e-2f);
         }
         else {
             this_result.result = test_result::INVALID;

--- a/tests/testing_commons/testing_utils.cuh
+++ b/tests/testing_commons/testing_utils.cuh
@@ -172,6 +172,12 @@ void initialize(T **d_i, T **d_o, std::vector<float> &i_ref, std::vector<float> 
             i_ref[idx] = float(i_t[idx]); 
         }
         #endif
+        #if defined(KITTENS_BLACKWELL)
+        else if constexpr (std::is_same_v<T, fp8e8m0>) {
+            i_t[idx] = __nv_fp8_e8m0(f); 
+            i_ref[idx] = float(i_t[idx]); 
+        }
+        #endif
         else {
             assert(false && "Unsupported data type");
         }
@@ -304,6 +310,12 @@ test_result validate(T *d_i, T *d_o, const std::vector<float> &i_ref, std::vecto
         else if constexpr(std::is_same_v<T, fp8e5m2>) {
             o[idx] = float(o_t[idx]);
             o_ref[idx] = float(__nv_fp8_e5m2(o_ref[idx])); 
+        }
+        #endif
+        #if defined(KITTENS_BLACKWELL)
+        else if constexpr(std::is_same_v<T, fp8e8m0>) {
+            o[idx] = float(o_t[idx]);
+            o_ref[idx] = float(__nv_fp8_e8m0(o_ref[idx])); 
         }
         #endif
         else {


### PR DESCRIPTION
Closes #188

Removes the `static_assert`s in `sv.cuh` that blocked fp8 shared vector instantiation and adds the missing scalar convertors + tests.

**Changes** :

 `include/types/shared/sv.cuh` : remove two `static_assert`s blocking fp8 sv types
 `include/common/base_types.cuh` : add 12 scalar convertors: `bf16↔fp8e4m3`, `half↔fp8e4m3`, `bf16↔fp8e5m2`, `half↔fp8e5m2` (Hopper+), `bf16↔fp8e8m0`, `half↔fp8e8m0`. 
 `tests/testing_commons/testing_utils.cuh` : add fp8e8m0 branches to `initialize` and `validate` (Blackwell)
 `tests/testing_commons/testing_commons.cuh` : relax eps to 0.1 for fp8 in `wrapper_1d` (fp8e4m3 quantization step is 0.0625 > default 0.05 eps), mirrors existing `wrapper_2d` logic
 `tests/group/shared/vec/conversions.cu` : bf16→fp8→bf16 round-trip tests for e4m3, e5m2  and e8m0 
 `tests/group/memory/vec/global_to_shared.cu` : load/store and async load/store tests for all three fp8 sv types

fp8 tests use `sv<T, 16*S>` directly instead of `col_vec<st<...>>` because `TILE_COL_DIM<fp8>=32` makes square `st<fp8, 16*S, 16*S>` invalid for odd S.

