### PR TITLE
Explicitly cast char to int8_t

### DIFF
--- a/include/common/base_types.cuh
+++ b/include/common/base_types.cuh
@@ -378,7 +378,7 @@ template<> struct packing<char> {
     static __device__ inline constexpr int num() { return 1; }
     using unpacked_type = char; // for compatibility
     using packed_type = int8_4;
-    static __device__ inline constexpr int8_4 pack(const char &i) { return int8_4{i, i, i, i}; } // this replication makes code cleaner later.
+    static __device__ inline constexpr int8_4 pack(const char &i) { const int8_t v = static_cast<int8_t>(i); return int8_4{v, v, v, v}; } // this replication makes code cleaner later.
 };
 template<> struct packing<int8> {
     static __device__ inline constexpr int num() { return 1; }


### PR DESCRIPTION
Hi, I was trying to get ThunderKittens to work on my DGX Spark and was hitting a compiler error with this char getting cast to an int8_t. From what I understand, char is unsigned on Arm, and so this was erroring out. I recognize that `i` is getting passed in as a reference, but I would be extremely surprised if this static_cast didn't compile to a no-op and keep that `i` in a register.   