### PR TITLE
Use XOR shuffles for register tile reductions

### DIFF
--- a/include/common/util.cuh
+++ b/include/common/util.cuh
@@ -129,6 +129,25 @@ __device__ inline float2 packed_shfl_down_sync<float2>(uint32_t mask, const floa
     return r;
 }
 /**
+ * @brief Perform a shuffle xor operation on a packed type synchronously across a warp.
+ * @tparam T The type of the value to be shuffled.
+ * @param mask[in] The mask of active threads.
+ * @param f[in] The value to be shuffled.
+ * @param lane_mask[in] The xor mask used to select the source lane.
+ * @return The result of the shuffle operation.
+ */
+template<typename T>
+__device__ static inline T packed_shfl_xor_sync(uint32_t mask, const T &f, int lane_mask) {
+    return __shfl_xor_sync(mask, f, lane_mask);
+}
+template<>
+__device__ inline float2 packed_shfl_xor_sync<float2>(uint32_t mask, const float2 &f, int lane_mask) {
+    float2 r;
+    r.x = __shfl_xor_sync(mask, f.x, lane_mask);
+    r.y = __shfl_xor_sync(mask, f.y, lane_mask);
+    return r;
+}
+/**
  * @brief Perform a packed shuffle operation synchronously across a warp.
  * @tparam T The type of the value to be shuffled.
  * @param mask[in] The mask of active threads.

--- a/include/ops/group/register/tile/reductions.cuh
+++ b/include/ops/group/register/tile/reductions.cuh
@@ -26,7 +26,6 @@ __device__ static inline void row_reduce(V &row_accum, const T &src, const V &sr
 
     using dtype = V::dtype;
 
-    const int leader = threadIdx.x & 0x1C; // 11100 in binary
     #pragma unroll
     for(int i = 0; i < T::height; i++) {
         dtype accum_top_row    = op::template op<dtype>(src.tiles[i][0].data[0], src.tiles[i][0].data[2]);
@@ -45,10 +44,8 @@ __device__ static inline void row_reduce(V &row_accum, const T &src, const V &sr
 
         // Now we need to do a lil shuffle to make everyone happy.
 
-        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_down_sync(MASK_ALL, accum_packed, 2));
-        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_down_sync(MASK_ALL, accum_packed, 1));
-
-        accum_packed = packed_shfl_sync(MASK_ALL, accum_packed, leader);
+        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_xor_sync(MASK_ALL, accum_packed, 2));
+        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_xor_sync(MASK_ALL, accum_packed, 1));
 
         if(reset) {
             row_accum[i][0] = accum_packed;
@@ -81,7 +78,6 @@ __device__ static inline void row_reduce(V &row_accum, const T &src, const V &sr
 
     using dtype = V::dtype;
 
-    const int leader = threadIdx.x & 0x3; // 00011 in binary
     #pragma unroll
     for(int i = 0; i < T::height; i++) {
         dtype accum_top_rows    = op::template op<dtype>(src.tiles[i][0].data[0], src.tiles[i][0].data[1]);
@@ -97,16 +93,13 @@ __device__ static inline void row_reduce(V &row_accum, const T &src, const V &sr
 
         // Now we need to do a lil shuffle to make everyone happy.
 
-        accum_top_rows = op::template op<dtype>(accum_top_rows, packed_shfl_down_sync(MASK_ALL, accum_top_rows, 16));
-        accum_top_rows = op::template op<dtype>(accum_top_rows, packed_shfl_down_sync(MASK_ALL, accum_top_rows, 8));
-        accum_top_rows = op::template op<dtype>(accum_top_rows, packed_shfl_down_sync(MASK_ALL, accum_top_rows, 4));
+        accum_top_rows = op::template op<dtype>(accum_top_rows, packed_shfl_xor_sync(MASK_ALL, accum_top_rows, 16));
+        accum_top_rows = op::template op<dtype>(accum_top_rows, packed_shfl_xor_sync(MASK_ALL, accum_top_rows, 8));
+        accum_top_rows = op::template op<dtype>(accum_top_rows, packed_shfl_xor_sync(MASK_ALL, accum_top_rows, 4));
 
-        accum_bottom_rows = op::template op<dtype>(accum_bottom_rows, packed_shfl_down_sync(MASK_ALL, accum_bottom_rows, 16));
-        accum_bottom_rows = op::template op<dtype>(accum_bottom_rows, packed_shfl_down_sync(MASK_ALL, accum_bottom_rows, 8));
-        accum_bottom_rows = op::template op<dtype>(accum_bottom_rows, packed_shfl_down_sync(MASK_ALL, accum_bottom_rows, 4));
-
-        accum_top_rows    = packed_shfl_sync(MASK_ALL, accum_top_rows,    leader);
-        accum_bottom_rows = packed_shfl_sync(MASK_ALL, accum_bottom_rows, leader);
+        accum_bottom_rows = op::template op<dtype>(accum_bottom_rows, packed_shfl_xor_sync(MASK_ALL, accum_bottom_rows, 16));
+        accum_bottom_rows = op::template op<dtype>(accum_bottom_rows, packed_shfl_xor_sync(MASK_ALL, accum_bottom_rows, 8));
+        accum_bottom_rows = op::template op<dtype>(accum_bottom_rows, packed_shfl_xor_sync(MASK_ALL, accum_bottom_rows, 4));
 
         if(reset) {
             row_accum[i][0] = accum_top_rows;
@@ -144,7 +137,6 @@ __device__ static inline void col_reduce(V &col_accum, const T &src, const V &sr
 
     using dtype = V::dtype;
 
-    const int leader = threadIdx.x & 0x3; // 00011 in binary
     #pragma unroll
     for(int j = 0; j < T::width; j++) {
         dtype accum_left_cols  = op::template op<dtype>(src.tiles[0][j].data[0], src.tiles[0][j].data[1]);
@@ -160,16 +152,13 @@ __device__ static inline void col_reduce(V &col_accum, const T &src, const V &sr
 
         // Now we need to do a lil shuffle to make everyone happy.
 
-        accum_left_cols = op::template op<dtype>(accum_left_cols, packed_shfl_down_sync(MASK_ALL, accum_left_cols, 16));
-        accum_left_cols = op::template op<dtype>(accum_left_cols, packed_shfl_down_sync(MASK_ALL, accum_left_cols, 8));
-        accum_left_cols = op::template op<dtype>(accum_left_cols, packed_shfl_down_sync(MASK_ALL, accum_left_cols, 4));
+        accum_left_cols = op::template op<dtype>(accum_left_cols, packed_shfl_xor_sync(MASK_ALL, accum_left_cols, 16));
+        accum_left_cols = op::template op<dtype>(accum_left_cols, packed_shfl_xor_sync(MASK_ALL, accum_left_cols, 8));
+        accum_left_cols = op::template op<dtype>(accum_left_cols, packed_shfl_xor_sync(MASK_ALL, accum_left_cols, 4));
 
-        accum_right_cols = op::template op<dtype>(accum_right_cols, packed_shfl_down_sync(MASK_ALL, accum_right_cols, 16));
-        accum_right_cols = op::template op<dtype>(accum_right_cols, packed_shfl_down_sync(MASK_ALL, accum_right_cols, 8));
-        accum_right_cols = op::template op<dtype>(accum_right_cols, packed_shfl_down_sync(MASK_ALL, accum_right_cols, 4));
-
-        accum_left_cols  = packed_shfl_sync(MASK_ALL, accum_left_cols,  leader);
-        accum_right_cols = packed_shfl_sync(MASK_ALL, accum_right_cols, leader);
+        accum_right_cols = op::template op<dtype>(accum_right_cols, packed_shfl_xor_sync(MASK_ALL, accum_right_cols, 16));
+        accum_right_cols = op::template op<dtype>(accum_right_cols, packed_shfl_xor_sync(MASK_ALL, accum_right_cols, 8));
+        accum_right_cols = op::template op<dtype>(accum_right_cols, packed_shfl_xor_sync(MASK_ALL, accum_right_cols, 4));
 
         if(reset) {
             col_accum[j][0] = accum_left_cols;
@@ -204,7 +193,6 @@ __device__ static inline void col_reduce(V &col_accum, const T &src, const V &sr
     static_assert(V::outer_dim == T::width); // compatible size
 
     using dtype = V::dtype;
-    const int leader = threadIdx.x & 0x1C; // 11100 in binary
     #pragma unroll
     for(int j = 0; j < T::width; j++) { // note now width is the outer loop
         dtype accum_left_col  = op::template op<dtype>(src.tiles[0][j].data[0], src.tiles[0][j].data[2]);
@@ -223,10 +211,8 @@ __device__ static inline void col_reduce(V &col_accum, const T &src, const V &sr
 
         // Now we need to do a lil shuffle to make everyone happy.
 
-        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_down_sync(MASK_ALL, accum_packed, 2));
-        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_down_sync(MASK_ALL, accum_packed, 1));
-
-        accum_packed = packed_shfl_sync(MASK_ALL, accum_packed, leader);
+        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_xor_sync(MASK_ALL, accum_packed, 2));
+        accum_packed = op::template op<dtype>(accum_packed, packed_shfl_xor_sync(MASK_ALL, accum_packed, 1));
 
         if(reset) {
             col_accum[j][0] = accum_packed;

--- a/tests/group/register/tile/reductions.cu
+++ b/tests/group/register/tile/reductions.cu
@@ -135,6 +135,104 @@ struct max_broadcast_col {
     }
 };
 
+__device__ static inline bool same_float2_as_leader(float2 value, int leader) {
+    float leader_x = __shfl_sync(0xffffffff, value.x, leader);
+    float leader_y = __shfl_sync(0xffffffff, value.y, leader);
+    return __float_as_uint(value.x) == __float_as_uint(leader_x) &&
+           __float_as_uint(value.y) == __float_as_uint(leader_y);
+}
+
+template<kittens::ducks::rv::all RV>
+__device__ static inline bool rv_matches_leader_bits(const RV &accum, int leader) {
+    bool matches = true;
+    #pragma unroll
+    for(int i = 0; i < RV::outer_dim; i++) {
+        #pragma unroll
+        for(int j = 0; j < RV::inner_dim; j++) {
+            matches &= same_float2_as_leader(accum[i][j], leader);
+        }
+    }
+    return matches;
+}
+
+template<int H, int W, gl_t GLT>
+__device__ static inline void write_bitwise_check_result(const GLT &output, bool matches) {
+    // Emit a single sentinel so the usual host validator can catch any lane-level bit mismatch.
+    #pragma unroll
+    for(int idx = kittens::laneid(); idx < H*W*256; idx += kittens::WARP_THREADS) {
+        output.raw_ptr[idx] = 0.0f;
+    }
+    unsigned mismatch_mask = __ballot_sync(0xffffffff, !matches);
+    if(kittens::laneid() == 0) {
+        output.raw_ptr[0] = mismatch_mask ? 1.0f : 0.0f;
+    }
+}
+
+struct sum_bitwise_row {
+    using dtype = float;
+    template<int H, int W, int NW, kittens::ducks::rt_layout::all L> using valid = std::bool_constant<NW == 1 && W*H<=64>; // this is warp-level
+    static inline const std::string test_identifier = "reg_sum_bitwise_row";
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for(int i = 0; i < o_ref.size(); i++) o_ref[i] = 0.0f;
+    }
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __device__ static void device_func(const GLT &input, const GLT &output) {
+        kittens::rt_fl<16*H, 16*W, L> reg_tile;
+        kittens::warp::load(reg_tile, input, {});
+        typename kittens::rt_fl<16*H, 16*W, L>::col_vec accum;
+        kittens::warp::row_sum(accum, reg_tile);
+        int leader = std::is_same_v<L, kittens::ducks::rt_layout::row> ? (kittens::laneid() & 0x1c) : (kittens::laneid() & 0x3);
+        write_bitwise_check_result<H, W>(output, rv_matches_leader_bits(accum, leader));
+    }
+};
+struct sum_bitwise_col {
+    using dtype = float;
+    template<int H, int W, int NW, kittens::ducks::rt_layout::all L> using valid = std::bool_constant<NW == 1 && W*H<=64>; // this is warp-level
+    static inline const std::string test_identifier = "reg_sum_bitwise_col";
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for(int i = 0; i < o_ref.size(); i++) o_ref[i] = 0.0f;
+    }
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __device__ static void device_func(const GLT &input, const GLT &output) {
+        kittens::rt_fl<16*H, 16*W, L> reg_tile;
+        kittens::warp::load(reg_tile, input, {});
+        typename kittens::rt_fl<16*H, 16*W, L>::row_vec accum;
+        kittens::warp::col_sum(accum, reg_tile);
+        int leader = std::is_same_v<L, kittens::ducks::rt_layout::col> ? (kittens::laneid() & 0x1c) : (kittens::laneid() & 0x3);
+        write_bitwise_check_result<H, W>(output, rv_matches_leader_bits(accum, leader));
+    }
+};
+struct prod_bitwise_row {
+    using dtype = float;
+    template<int H, int W, int NW, kittens::ducks::rt_layout::all L> using valid = std::bool_constant<NW == 1 && W*H<=64>; // this is warp-level
+    static inline const std::string test_identifier = "reg_prod_bitwise_row";
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for(int i = 0; i < o_ref.size(); i++) o_ref[i] = 0.0f;
+    }
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __device__ static void device_func(const GLT &input, const GLT &output) {
+        kittens::rt_fl<16*H, 16*W, L> reg_tile;
+        kittens::warp::load(reg_tile, input, {});
+        typename kittens::rt_fl<16*H, 16*W, L>::col_vec accum;
+        kittens::warp::row_prod(accum, reg_tile);
+        int leader = std::is_same_v<L, kittens::ducks::rt_layout::row> ? (kittens::laneid() & 0x1c) : (kittens::laneid() & 0x3);
+        write_bitwise_check_result<H, W>(output, rv_matches_leader_bits(accum, leader));
+    }
+};
+struct prod_bitwise_col {
+    using dtype = float;
+    template<int H, int W, int NW, kittens::ducks::rt_layout::all L> using valid = std::bool_constant<NW == 1 && W*H<=64>; // this is warp-level
+    static inline const std::string test_identifier = "reg_prod_bitwise_col";
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for(int i = 0; i < o_ref.size(); i++) o_ref[i] = 0.0f;
+    }
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __device__ static void device_func(const GLT &input, const GLT &output) {
+        kittens::rt_fl<16*H, 16*W, L> reg_tile;
+        kittens::warp::load(reg_tile, input, {});
+        typename kittens::rt_fl<16*H, 16*W, L>::row_vec accum;
+        kittens::warp::col_prod(accum, reg_tile);
+        int leader = std::is_same_v<L, kittens::ducks::rt_layout::col> ? (kittens::laneid() & 0x1c) : (kittens::laneid() & 0x3);
+        write_bitwise_check_result<H, W>(output, rv_matches_leader_bits(accum, leader));
+    }
+};
+
 void group::reg::tile::reductions::tests(test_data &results) {
     std::cout << " ----- Starting ops/group/register/tile/reductions tests! -----\n" << std::endl;
     constexpr int SIZE = INTENSITY_1 ? 2  :
@@ -153,6 +251,14 @@ void group::reg::tile::reductions::tests(test_data &results) {
     sweep_size_2d_warp<max_broadcast_row, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
     sweep_size_2d_warp<max_broadcast_col, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
     sweep_size_2d_warp<max_broadcast_col, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
+    sweep_size_2d_warp<sum_bitwise_row, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
+    sweep_size_2d_warp<sum_bitwise_row, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
+    sweep_size_2d_warp<sum_bitwise_col, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
+    sweep_size_2d_warp<sum_bitwise_col, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
+    sweep_size_2d_warp<prod_bitwise_row, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
+    sweep_size_2d_warp<prod_bitwise_row, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
+    sweep_size_2d_warp<prod_bitwise_col, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
+    sweep_size_2d_warp<prod_bitwise_col, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
     std::cout << std::endl;
 }
 

--- a/tests/group/register/tile/reductions.cu
+++ b/tests/group/register/tile/reductions.cu
@@ -90,6 +90,50 @@ struct broadcast_col {
         kittens::warp::store(output, reg_tile, {});
     }
 };
+struct max_broadcast_row {
+    template<int H, int W, int NW, kittens::ducks::rt_layout::all L> using valid = std::bool_constant<NW == 1 && W*H<=64>; // this is warp-level
+    static inline const std::string test_identifier = "reg_max_broadcast_row";
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for(int i = 0; i < H*16; i++) {
+            float row_max = i_ref[i*W*16];
+            for(int j = 1; j < W*16; j++) {
+                float val = i_ref[i*W*16+j];
+                row_max = val > row_max ? val : row_max;
+            }
+            for(int j = 0; j < W*16; j++) o_ref[i*W*16+j] = row_max;
+        }
+    }
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __device__ static void device_func(const GLT &input, const GLT &output) {
+        kittens::rt_fl<16*H, 16*W, L> reg_tile;
+        kittens::warp::load(reg_tile, input, {});
+        typename kittens::rt_fl<16*H, 16*W, L>::col_vec accum;
+        kittens::warp::row_max(accum, reg_tile);
+        kittens::warp::broadcast_row(reg_tile, accum);
+        kittens::warp::store(output, reg_tile, {});
+    }
+};
+struct max_broadcast_col {
+    template<int H, int W, int NW, kittens::ducks::rt_layout::all L> using valid = std::bool_constant<NW == 1 && W*H<=64>; // this is warp-level
+    static inline const std::string test_identifier = "reg_max_broadcast_col";
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __host__ static void host_func(const std::vector<float> &i_ref, std::vector<float> &o_ref) {
+        for(int i = 0; i < W*16; i++) {
+            float col_max = i_ref[i];
+            for(int j = 1; j < H*16; j++) {
+                float val = i_ref[i+j*W*16];
+                col_max = val > col_max ? val : col_max;
+            }
+            for(int j = 0; j < H*16; j++) o_ref[i+j*W*16] = col_max;
+        }
+    }
+    template<int H, int W, int NW, gl_t GLT, kittens::ducks::rt_layout::all L> __device__ static void device_func(const GLT &input, const GLT &output) {
+        kittens::rt_fl<16*H, 16*W, L> reg_tile;
+        kittens::warp::load(reg_tile, input, {});
+        typename kittens::rt_fl<16*H, 16*W, L>::row_vec accum;
+        kittens::warp::col_max(accum, reg_tile);
+        kittens::warp::broadcast_col(reg_tile, accum);
+        kittens::warp::store(output, reg_tile, {});
+    }
+};
 
 void group::reg::tile::reductions::tests(test_data &results) {
     std::cout << " ----- Starting ops/group/register/tile/reductions tests! -----\n" << std::endl;
@@ -105,6 +149,10 @@ void group::reg::tile::reductions::tests(test_data &results) {
     sweep_size_2d_warp<broadcast_row, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
     sweep_size_2d_warp<broadcast_col, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
     sweep_size_2d_warp<broadcast_col, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
+    sweep_size_2d_warp<max_broadcast_row, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
+    sweep_size_2d_warp<max_broadcast_row, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
+    sweep_size_2d_warp<max_broadcast_col, SIZE, SIZE, kittens::ducks::rt_layout::row>::run(results);
+    sweep_size_2d_warp<max_broadcast_col, SIZE, SIZE, kittens::ducks::rt_layout::col>::run(results);
     std::cout << std::endl;
 }
 


### PR DESCRIPTION

## Summary

This replaces the down-shuffle plus leader-broadcast pattern in register tile reductions with butterfly/XOR shuffles. [Documentation: Warp Shuffle Functions](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#warp-shuffle-functions)

Following @benjaminfspector's [comment](https://twitter.com/bfspector/status/2057660506304057429) on my recent TK blog post:

> What a wonderful, in-depth post! I'm immensely appreciative of the effort that must have gone into this. I've added a link to the readme of the TK repo. And footnote (2) is a good idea -- an xor instead of down shuffle would probably save a few instructions!

The previous register-tile reduction pattern computed the reduced value in a leader lane, then used an indexed shuffle to broadcast that value to the rest of the lane subgroup. For the lane subgroups used by these register tile reductions, the XOR butterfly tree leaves every lane in the subgroup with the reduced value directly, so the final broadcast shuffle is no longer needed.

This does not change the public DSL API for the reductions ops.

## Changes

- Add `packed_shfl_xor_sync(...)`, including the `float2` specialisation.
- Update register tile row/column reductions to use XOR shuffle trees:
  - row-4 style groups: `xor 2`, `xor 1`
  - stride-8 style groups: `xor 16`, `xor 8`, `xor 4`
- Add finite row/column max coverage for register tile reductions.

This PR intentionally does not change register vector reductions or shared-memory reductions.

## SASS Checks

I first checked the isolated shuffle pattern with a standalone `float2` CUDA repro targeting `sm_90a` on [Godbolt Compiler Explorer](https://godbolt.org).

A standalone `sm_90a` SASS check for the isolated `float2` shuffle pattern shows that the row-4 case changes from two `SHFL.DOWN` pairs plus one `SHFL.IDX` pair to two `SHFL.BFLY` pairs. The stride-8 case changes from three `SHFL.DOWN` pairs plus one `SHFL.IDX` pair to three `SHFL.BFLY` pairs. In both cases, the final indexed broadcast is removed.

Annotated:

```sass
xor_stride8:
 LDC R1, c[0x0][0x28] 
 S2R R0, SR_TID.X 
 ULDC.64 UR4, c[0x0][0x218] --> Addr calc
 ULDC.64 UR6, c[0x0][0x210] --> Addr calc
 SHF.L.U32 R0, R0, 0x3, RZ 
 LOP3.LUT R10, R0, 0xf8, RZ, 0xc0, !PT 
 IADD3 R2, P0, R10, UR4, RZ --> Addr calc
 IADD3.X R3, RZ, UR5, RZ, P0, !PT --> Addr calc
 ULDC.64 UR4, c[0x0][0x208] 
 LDG.E.64.CONSTANT R4, desc[UR4][R2.64] --> (Loads one float2: Since each float is 32 bits, this lands in two registers)
 IADD3 R2, P0, R10, UR6, RZ 
 IADD3.X R3, RZ, UR7, RZ, P0, !PT 
 SHFL.BFLY PT, R7, R4, 0x10, 0x1f --> 1 (One for x) 
 SHFL.BFLY PT, R0, R5, 0x10, 0x1f --> 2 (One for y)
		         *** I added these, just to understand these two lines **
						 R4 = x.x
						 R5 = x.y
						 R7 = shuffled x.x
						 R0 = shuffled x.y
						 *** ***
 FADD R7, R4, R7 --> x = add2(x, shfl_xor2(x, 16));
 FADD R0, R5, R0 --> x = add2(x, shfl_xor2(x, 16));
 SHFL.BFLY PT, R6, R7, 0x8, 0x1f --> 3
 SHFL.BFLY PT, R9, R0, 0x8, 0x1f --> 4
 FADD R6, R7, R6 
 FADD R9, R0, R9 
 SHFL.BFLY PT, R11, R6, 0x4, 0x1f --> 5
 SHFL.BFLY PT, R8, R9, 0x4, 0x1f --> 6
 FADD R4, R6, R11 
 FADD R5, R9, R8 
 STG.E.64 desc[UR4][R2.64], R4 
 EXIT 
...
old_stride8:
 LDC R1, c[0x0][0x28] 
 S2R R8, SR_TID.X 
 ULDC.64 UR4, c[0x0][0x218] 
 ULDC.64 UR6, c[0x0][0x210] 
 SHF.L.U32 R0, R8, 0x3, RZ 
 LOP3.LUT R12, R0, 0xf8, RZ, 0xc0, !PT 
 IADD3 R2, P0, R12, UR4, RZ 
 IADD3.X R3, RZ, UR5, RZ, P0, !PT 
 ULDC.64 UR4, c[0x0][0x208] 
 LDG.E.64.CONSTANT R2, desc[UR4][R2.64] 
 LOP3.LUT R8, R8, 0x3, RZ, 0xc0, !PT 
 SHFL.DOWN PT, R5, R2, 0x10, 0x1f --> 1
 SHFL.DOWN PT, R0, R3, 0x10, 0x1f --> 2
 FADD R5, R2, R5 
 IADD3 R2, P0, R12, UR6, RZ 
 FADD R0, R3, R0 
 SHFL.DOWN PT, R4, R5, 0x8, 0x1f --> 3
 IADD3.X R3, RZ, UR7, RZ, P0, !PT 
 SHFL.DOWN PT, R7, R0, 0x8, 0x1f --> 4
 FADD R4, R5, R4 
 FADD R7, R0, R7 
 SHFL.DOWN PT, R9, R4, 0x4, 0x1f --> 5
 SHFL.DOWN PT, R6, R7, 0x4, 0x1f --> 6
 FADD R9, R4, R9 
 FADD R6, R7, R6 
 SHFL.IDX PT, R10, R9, R8, 0x1f --> 7
 SHFL.IDX PT, R11, R6, R8, 0x1f --> 8
 STG.E.64 desc[UR4][R2.64], R10 
 EXIT 
...
xor_row4:
 LDC R1, c[0x0][0x28] 
 S2R R0, SR_TID.X 
 ULDC.64 UR4, c[0x0][0x218] 
 ULDC.64 UR6, c[0x0][0x210] 
 SHF.L.U32 R0, R0, 0x3, RZ 
 LOP3.LUT R4, R0, 0xf8, RZ, 0xc0, !PT 
 IADD3 R2, P0, R4, UR4, RZ 
 IADD3.X R3, RZ, UR5, RZ, P0, !PT 
 ULDC.64 UR4, c[0x0][0x208] 
 LDG.E.64.CONSTANT R2, desc[UR4][R2.64] 
 IADD3 R4, P0, R4, UR6, RZ 
 SHFL.BFLY PT, R5, R2, 0x2, 0x1f --> 1 
 SHFL.BFLY PT, R0, R3, 0x2, 0x1f --> 2
 FADD R6, R2, R5 
 IADD3.X R5, RZ, UR7, RZ, P0, !PT 
 FADD R0, R3, R0 
 SHFL.BFLY PT, R7, R6, 0x1, 0x1f --> 3
 SHFL.BFLY PT, R9, R0, 0x1, 0x1f --> 4
 FADD R8, R6, R7 
 FADD R9, R0, R9 
 STG.E.64 desc[UR4][R4.64], R8 
 EXIT 
...
old_row4:
 LDC R1, c[0x0][0x28] 
 S2R R6, SR_TID.X 
 ULDC.64 UR4, c[0x0][0x218] 
 ULDC.64 UR6, c[0x0][0x210] 
 SHF.L.U32 R0, R6, 0x3, RZ 
 LOP3.LUT R10, R0, 0xf8, RZ, 0xc0, !PT 
 IADD3 R2, P0, R10, UR4, RZ 
 IADD3.X R3, RZ, UR5, RZ, P0, !PT 
 ULDC.64 UR4, c[0x0][0x208] 
 LDG.E.64.CONSTANT R2, desc[UR4][R2.64] 
 LOP3.LUT R6, R6, 0x1c, RZ, 0xc0, !PT 
 SHFL.DOWN PT, R5, R2, 0x2, 0x1f --> (1)
 SHFL.DOWN PT, R0, R3, 0x2, 0x1f --> (2)
 FADD R5, R2, R5 
 IADD3 R2, P0, R10, UR6, RZ 
 FADD R0, R3, R0 
 SHFL.DOWN PT, R4, R5, 0x1, 0x1f --> (3)
 IADD3.X R3, RZ, UR7, RZ, P0, !PT 
 SHFL.DOWN PT, R7, R0, 0x1, 0x1f --> (4) 
 FADD R4, R5, R4 
 FADD R7, R0, R7 
 SHFL.IDX PT, R8, R4, R6, 0x1f --> (5) 
 SHFL.IDX PT, R9, R7, R6, 0x1f --> (6) 
 STG.E.64 desc[UR4][R2.64], R8 
 EXIT 
...
```

I also checked a focused TK SASS repro that instantiates actual `warp::row_sum` / `warp::col_sum` register-tile reductions. The compiled SASS emits the expected butterfly masks:

```bash
5:              Function : tk_col_reduce_row_layout
133:        /*03f0*/                   SHFL.BFLY PT, R3, R0, 0x10, 0x1f ;             /* 0x0e001f0000037f89 */
141:        /*0430*/                   SHFL.BFLY PT, R7, R4, 0x10, 0x1f ;             /* 0x0e001f0004077f89 */
147:        /*0460*/                   SHFL.BFLY PT, R9, R22, 0x10, 0x1f ;            /* 0x0e001f0016097f89 */
151:        /*0480*/                   SHFL.BFLY PT, R6, R5, 0x10, 0x1f ;             /* 0x0e001f0005067f89 */
155:        /*04a0*/                   SHFL.BFLY PT, R2, R3, 0x8, 0x1f ;              /* 0x0d001f0003027f89 */
159:        /*04c0*/                   SHFL.BFLY PT, R0, R7, 0x8, 0x1f ;              /* 0x0d001f0007007f89 */
163:        /*04e0*/                   SHFL.BFLY PT, R11, R8, 0x8, 0x1f ;             /* 0x0d001f00080b7f89 */
167:        /*0500*/                   SHFL.BFLY PT, R13, R6, 0x8, 0x1f ;             /* 0x0d001f00060d7f89 */
171:        /*0520*/                   SHFL.BFLY PT, R5, R2, 0x4, 0x1f ;              /* 0x0c801f0002057f89 */
175:        /*0540*/                   SHFL.BFLY PT, R9, R0, 0x4, 0x1f ;              /* 0x0c801f0000097f89 */
179:        /*0560*/                   SHFL.BFLY PT, R4, R11, 0x4, 0x1f ;             /* 0x0c801f000b047f89 */
183:        /*0580*/                   SHFL.BFLY PT, R10, R13, 0x4, 0x1f ;            /* 0x0c801f000d0a7f89 */
234:            Function : tk_row_reduce_col_layout
362:        /*03f0*/                   SHFL.BFLY PT, R3, R0, 0x10, 0x1f ;             /* 0x0e001f0000037f89 */
370:        /*0430*/                   SHFL.BFLY PT, R7, R4, 0x10, 0x1f ;             /* 0x0e001f0004077f89 */
376:        /*0460*/                   SHFL.BFLY PT, R9, R22, 0x10, 0x1f ;            /* 0x0e001f0016097f89 */
380:        /*0480*/                   SHFL.BFLY PT, R6, R5, 0x10, 0x1f ;             /* 0x0e001f0005067f89 */
384:        /*04a0*/                   SHFL.BFLY PT, R2, R3, 0x8, 0x1f ;              /* 0x0d001f0003027f89 */
388:        /*04c0*/                   SHFL.BFLY PT, R0, R7, 0x8, 0x1f ;              /* 0x0d001f0007007f89 */
392:        /*04e0*/                   SHFL.BFLY PT, R11, R8, 0x8, 0x1f ;             /* 0x0d001f00080b7f89 */
396:        /*0500*/                   SHFL.BFLY PT, R13, R6, 0x8, 0x1f ;             /* 0x0d001f00060d7f89 */
400:        /*0520*/                   SHFL.BFLY PT, R5, R2, 0x4, 0x1f ;              /* 0x0c801f0002057f89 */
404:        /*0540*/                   SHFL.BFLY PT, R9, R0, 0x4, 0x1f ;              /* 0x0c801f0000097f89 */
408:        /*0560*/                   SHFL.BFLY PT, R4, R11, 0x4, 0x1f ;             /* 0x0c801f000b047f89 */
412:        /*0580*/                   SHFL.BFLY PT, R10, R13, 0x4, 0x1f ;            /* 0x0c801f000d0a7f89 */
463:            Function : tk_col_reduce_col_layout
607:        /*0470*/                   SHFL.BFLY PT, R3, R8, 0x2, 0x1f ;              /* 0x0c401f0008037f89 */
611:        /*0490*/                   SHFL.BFLY PT, R2, R7, 0x2, 0x1f ;              /* 0x0c401f0007027f89 */
615:        /*04b0*/                   SHFL.BFLY PT, R3, R4, 0x1, 0x1f ;              /* 0x0c201f0004037f89 */
619:        /*04d0*/                   SHFL.BFLY PT, R6, R5, 0x1, 0x1f ;              /* 0x0c201f0005067f89 */
660:            Function : tk_row_reduce_row_layout
804:        /*0470*/                   SHFL.BFLY PT, R3, R8, 0x2, 0x1f ;              /* 0x0c401f0008037f89 */
808:        /*0490*/                   SHFL.BFLY PT, R2, R7, 0x2, 0x1f ;              /* 0x0c401f0007027f89 */
812:        /*04b0*/                   SHFL.BFLY PT, R3, R4, 0x1, 0x1f ;              /* 0x0c201f0004037f89 */
816:        /*04d0*/                   SHFL.BFLY PT, R6, R5, 0x1, 0x1f ;              /* 0x0c201f0005067f89 */
```

The targeted grep output showed no `SHFL.DOWN` / `SHFL.IDX` in those focused TK reduction kernels.

## Validation

Tested on H100 with CUDA 13.0.

```bash
./unit_tests_reg_tile_reductions
```

```bash
ALL TESTS PASSED!
0 test template configurations deemed invalid
192 tests passed
0 tests failed
```

```bash
./unit_tests_reg_vec_reductions
```

```bash
ALL TESTS PASSED!
0 test template configurations deemed invalid
12 tests passed
0 tests failed
```

```bash
./unit_tests_reg_tile_all
```

```bash
ALL TESTS PASSED!
176 test template configurations deemed invalid
320 tests passed
0 tests failed
```

## Notes

For floating-point sum/product reductions, the butterfly tree can change the exact per-lane reduction order compared with broadcasting the leader lane's result. The mathematical reduction is the same, but bitwise-identical results are not the claim here. The focused register tile tests and nearby register vector regression tests pass on H100.
