### PR TITLE
fix: guard destroy() against moved-from TKParallelTensor

### DIFF
--- a/include/pyutils/parallel_tensor.cuh
+++ b/include/pyutils/parallel_tensor.cuh
@@ -272,6 +272,10 @@ struct TKParallelTensor {
     }
 
     __host__ inline void destroy() {
+        // Guard against moved-from objects: move constructor sets local_rank_ = -1.
+        // Also makes destroy() idempotent (safe to call multiple times).
+        if (local_rank_ < 0) return;
+
         // 1. Multicast cleanup
         if (multicast_ && multicast_ptr_) {
             brokers_.at({local_rank_, local_world_size_}).sync();


### PR DESCRIPTION
Fixes #180

## Bug

After `std::move()`, the move constructor sets `local_rank_ = -1` and `local_world_size_ = -1` as sentinel values (lines 136–137). However, `destroy()` called `brokers_.at({local_rank_, local_world_size_})` unconditionally on line 298, which throws `std::out_of_range` when the moved-from object is later destroyed.

**Minimal reproducer:**

```cpp
TKParallelTensor a(0, 1);
TKParallelTensor b = std::move(a);
// 'a' destructs -> destroy() -> brokers_.at({-1,-1}) -> throws
```

**Output before fix:**
```
terminate called after throwing an instance of 'std::out_of_range'
  what():  map::at
Aborted
```

## Fix

Add an early return at the top of `destroy()` when `local_rank_ < 0`:

```cpp
if (local_rank_ < 0) return;
```

This is correct because after a move all other cleanup sections are already no-ops:
- Section 1 (multicast): guarded by `if (multicast_ && multicast_ptr_)` — both `false`/`nullptr` after move
- Section 2 (IPC loop): `for (int i = 0; i < local_world_size_(-1); i++)` — never executes
- Section 3 (tensor): `data_.defined()` returns `false` after move
- Section 4 (member reset): already set to `-1`/`nullptr`/`0` by move constructor

As a side effect, this also makes `destroy()` idempotent — after a normal destroy `local_rank_` is set to `-1`, so a second call returns early instead of crashing.

**Output after fix:**
```
[destroy: rank=0 world=2]   <- valid object cleaned up normally
[broker sync rank=0]        <- sync still called on valid path
[destroy: rank=-1 world=-1] <- moved-from object
[moved-from object, returning early]
```