### PR TITLE
Add SM120/SM121 (GB10 / DGX Spark) support: WGMMA shim + kernel ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Altogether, this is less than 100 lines of code, and achieves about 855 TFLOPs o
 #### Hardware requirements
 
 * ThunderKittens is mainly built and tested for Hopper and Blackwell GPUs.
+* **GB10 / DGX Spark** (consumer Blackwell, `sm_121`): library primitives and H100 kernels run via a WGMMA shim — build with `make ARCH=SM121`.
 * We no longer actively support Ampere GPUs. However, contributions are welcomed!
 
 #### Build requirements
@@ -352,7 +353,7 @@ ThunderKittens has fairly comprehensive unit testing suite. Simply run `make -j`
 
 The `tests/Makefile` provides several options to customize the test:
 
-* `ARCH`: Set to `SM80`, `SM90`, `SM100`, `SM103`, or `SM120` to specify the target GPU architecture (default: `SM90`).
+* `ARCH`: Set to `SM80`, `SM90`, `SM100`, `SM103`, `SM120`, or `SM121` to specify the target GPU architecture (default: `SM90`). `SM121` targets GB10 (consumer Blackwell / DGX Spark): it uses the `SM120` feature set but emits native `sm_121a` SASS.
 * `COMP_LEVEL`: Set the compiler optimization level. Available options are `fast`, `debug`, and `profile` (default: fast).
 * `TEST_INTENSITY`: Set the level of test intensity. Higher levels compile more tests but take longer. Available options are 1, 2, 3, and 4 (default: 2).
 * `TEST_ALL`: Compile and run all available tests. You can also specify individual test sections or tests using flags like -DTEST_WARP_MEMORY or -DTEST_WARP_MEMORY_VEC_DSMEM.

--- a/include/ops/group/mma/mma.cuh
+++ b/include/ops/group/mma/mma.cuh
@@ -15,3 +15,9 @@
 #ifdef KITTENS_SM10X
 #include "tcgen05.cuh"
 #endif
+
+// SM120 (consumer Blackwell, e.g. GB10) has neither wgmma nor tcgen05; this shim
+// re-exposes the warpgroup WGMMA API on top of warp-level mma.sync.
+#ifdef KITTENS_SM120
+#include "warpgroup_sm120.cuh"
+#endif

--- a/include/ops/group/mma/warpgroup_sm120.cuh
+++ b/include/ops/group/mma/warpgroup_sm120.cuh
@@ -1,0 +1,227 @@
+/**
+ * @file
+ * @brief SM120 (consumer Blackwell, e.g. GB10 / sm_121) shim for the warpgroup
+ *        (group<4>) WGMMA API.
+ *
+ * SM120 has neither Hopper's `wgmma.mma_async` nor datacenter Blackwell's
+ * `tcgen05` tensor-memory MMA. The native way to drive its tensor cores is the
+ * warp-level `mma.sync` path in `warp.cuh`. This file re-exposes the
+ * `warpgroup::mma_*` / `mm_*` surface that H100 kernels and the `prototype/`
+ * LCF templates are written against, lowering each call to per-warp
+ * `warp::mma_*` so those kernels compile and run unchanged.
+ *
+ * Key facts that make this a correctness-preserving lowering:
+ *   - A 64-row warpgroup output tile is laid out as four 16-row bands, with
+ *     warp `w` owning rows [16w, 16w+16). This is exactly how `group<4>::load`
+ *     distributes a shared tile and how the WGMMA D fragment is partitioned, so
+ *     a per-warp `warp::mma` over band `w` yields the same register layout WGMMA
+ *     would have produced.
+ *   - `group<1>::load` into a col-layout (or row-layout, for ABt) register tile
+ *     performs the shared->register transpose-load via ldsm, matching the
+ *     operand layouts `warp::mma_*` expects.
+ *
+ * Performance note: this is synchronous. WGMMA's async overlap (the basis of the
+ * LCF producer/consumer pipeline) is lost, and shared operands are staged
+ * through registers. Kernels are CORRECT but not pipeline-optimal; hot kernels
+ * should be tuned per-kernel on top of this.
+ *
+ * RESERVED NAMED BARRIERS: mma_async_wait() uses bar.sync ids 12..15 (one per
+ * warpgroup). Kernels that use this shim must keep their own named barriers in
+ * 0..11. See the note on mma_async_wait below.
+ *
+ * Dtype coverage: bf16 only -- enforced by the static_assert below for every
+ * variant, including AB. The SM120 warp-level mma.sync path lacks the
+ * half->fp32 / fp8 / int8 base ops these warpgroup variants would need, so
+ * those dtypes are intentionally absent here.
+ */
+
+// ---------------------------------------------------------------------------
+//  Async-pipeline control ops -> no-ops / syncs (everything here is synchronous)
+// ---------------------------------------------------------------------------
+
+template<ducks::rt::all D> __device__ static inline void mma_fence(D &dst) {}
+__device__ static inline void mma_fence() {}
+__device__ static inline void mma_commit_group() {}
+// On H100, mma_async_wait is wgmma.wait_group.sync.aligned -- a WARPGROUP-WIDE
+// synchronization. The shim's MMA is synchronous per warp, but we still must
+// barrier all 4 warps here: kernels signal shared-memory reuse (e.g. arrive() on
+// a "compute done" semaphore from lane 0) right after this call, so without the
+// barrier warps 1-3 may still be reading A/B from shared when the producer
+// overwrites it (a WAR race).
+//
+// !!! RESERVED NAMED BARRIERS: this shim uses `bar.sync` id `8 + groupid()` (one
+// per warpgroup). A named barrier is a block-global resource (ids 0..15) with no
+// allocator, so any group that issues `bar.sync` on the same id with a different
+// thread cohort can cross-release this barrier (deadlock or WAR-race corruption).
+// Base 8 is chosen to be DISJOINT from the two barrier sets a shim-using kernel
+// also touches:
+//   - the LCF/LCSF/LCSC prototype templates (which the gemm runs on) use ids
+//     13 (producers::sync), 14 (consumers::sync), 15 (everyone::sync);
+//   - hand-written kernels use low ids -- mha_h100: groupid+4 (4/5/6) and a
+//     group<8> barrier on id 10; gemm finish: groupid+4 (4..7).
+// On GB10 only <=2 consumer warpgroups fit the 99 KB smem budget, so this uses
+// ids 8,9 -- clean against all of the above. (An earlier version used 12+groupid
+// = 12..15, which ALIASED the LCF template's 13/14/15: in the bf16_h100 gemm
+// (LCF + this shim) consumer warpgroup 1's mma_async_wait collided with the
+// producer's producers::sync(13). That is now fixed.) FORWARD-LOOKING CAVEAT:
+// ids 8..11 brush mha's id 10, so a future kernel that combines this shim's mma
+// with >2 consumer warpgroups AND a group<8>::sync(10) must re-audit. Kernels
+// using this shim MUST keep their own named barriers disjoint from `8+groupid()`.
+template<int N=0> __device__ static inline void mma_async_wait() {
+    KITTENS_CHECK_WARPGROUP
+    sync(8 + groupid());
+}
+
+// ---------------------------------------------------------------------------
+//  Dtype guard: the SM120 warp-level mma.sync path has complete coverage only
+//  for bf16 inputs. fp16/fp8/int8 warpgroup MMA is not implemented here (the
+//  warp::mma_*_base overloads in warp.cuh are incomplete for those on SM120).
+//  Without this check, an unsupported type produces a cryptic "no instance of
+//  overloaded function warp::mma_*" error; this turns it into a clear message.
+// ---------------------------------------------------------------------------
+#define KITTENS_SM120_WG_MMA_DTYPE_CHECK(T) \
+    static_assert(std::is_same_v<T, kittens::bf16>, \
+        "SM120 (GB10) warpgroup-MMA shim supports bf16 inputs only. fp16/fp8/int8 " \
+        "warpgroup MMA is not implemented on SM120 -- the warp-level mma.sync bases " \
+        "in warp.cuh are incomplete for these types. Use bf16, add the missing " \
+        "warp::mma_*_base overloads, or call warp-level mma directly. " \
+        "See include/ops/group/mma/warpgroup_sm120.cuh.")
+
+// ---------------------------------------------------------------------------
+//  Helper: load full B from shared into a per-warp register tile.
+//  Each of the 4 warps loads the complete B (group<1> scope).
+// ---------------------------------------------------------------------------
+
+// ===========================================================================
+//  mma_AB / mm_AB :  D = A @ B   (B is [K, N], loaded col-layout)
+// ===========================================================================
+
+// [(register A, shared B) -> register]
+template<ducks::rt::row_layout D, ducks::rt::row_layout A, ducks::st::all B, int accumulate=1>
+__device__ static inline void mma_AB(D &d, const A &a, const B &b) {
+    KITTENS_CHECK_WARPGROUP
+    using T_AB = typename A::T;
+    KITTENS_SM120_WG_MMA_DTYPE_CHECK(T_AB);
+    rt<T_AB, B::rows, B::cols, ducks::rt_layout::col> b_reg;
+    group<1>::load(b_reg, b);
+    if constexpr (!accumulate) group<1>::zero(d);
+    group<1>::mma_AB(d, a, b_reg, d);
+}
+template<ducks::rt::row_layout D, ducks::rt::row_layout A, ducks::st::all B>
+__device__ static inline void mm_AB(D &d, const A &a, const B &b) {
+    mma_AB<D, A, B, 0>(d, a, b);
+}
+
+// [(shared A, shared B) -> register]
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B, int accumulate=1>
+__device__ static inline void mma_AB(D &d, const A &a, const B &b) {
+    KITTENS_CHECK_WARPGROUP
+    using T_AB = typename A::T;
+    KITTENS_SM120_WG_MMA_DTYPE_CHECK(T_AB);
+    // warpgroup-collaborative load: warp w receives its 16*D::height-row band of A.
+    rt<T_AB, D::rows, A::cols, ducks::rt_layout::row> a_reg;
+    load(a_reg, a); // group<4>::load
+    rt<T_AB, B::rows, B::cols, ducks::rt_layout::col> b_reg;
+    group<1>::load(b_reg, b);
+    if constexpr (!accumulate) group<1>::zero(d);
+    group<1>::mma_AB(d, a_reg, b_reg, d);
+}
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B>
+__device__ static inline void mm_AB(D &d, const A &a, const B &b) {
+    mma_AB<D, A, B, 0>(d, a, b);
+}
+
+// ===========================================================================
+//  mma_ABt / mm_ABt :  D = A @ B^T   (B is [N, K], loaded row-layout)
+// ===========================================================================
+
+// [(register A, shared B) -> register]
+template<ducks::rt::row_layout D, ducks::rt::row_layout A, ducks::st::all B, int accumulate=1>
+__device__ static inline void mma_ABt(D &d, const A &a, const B &b) {
+    KITTENS_CHECK_WARPGROUP
+    using T_AB = typename A::T;
+    KITTENS_SM120_WG_MMA_DTYPE_CHECK(T_AB);
+    rt<T_AB, B::rows, B::cols, ducks::rt_layout::row> b_reg;
+    group<1>::load(b_reg, b);
+    if constexpr (!accumulate) group<1>::zero(d);
+    group<1>::mma_ABt(d, a, b_reg, d);
+}
+template<ducks::rt::row_layout D, ducks::rt::row_layout A, ducks::st::all B>
+__device__ static inline void mm_ABt(D &d, const A &a, const B &b) {
+    mma_ABt<D, A, B, 0>(d, a, b);
+}
+
+// [(shared A, shared B) -> register]
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B, int accumulate=1>
+__device__ static inline void mma_ABt(D &d, const A &a, const B &b) {
+    KITTENS_CHECK_WARPGROUP
+    using T_AB = typename A::T;
+    KITTENS_SM120_WG_MMA_DTYPE_CHECK(T_AB);
+    rt<T_AB, D::rows, A::cols, ducks::rt_layout::row> a_reg;
+    load(a_reg, a); // group<4>::load
+    rt<T_AB, B::rows, B::cols, ducks::rt_layout::row> b_reg;
+    group<1>::load(b_reg, b);
+    if constexpr (!accumulate) group<1>::zero(d);
+    group<1>::mma_ABt(d, a_reg, b_reg, d);
+}
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B>
+__device__ static inline void mm_ABt(D &d, const A &a, const B &b) {
+    mma_ABt<D, A, B, 0>(d, a, b);
+}
+
+// ===========================================================================
+//  mma_AtB / mm_AtB :  D = A^T @ B   (A is [K, M] shared, B is [K, N] shared)
+//  Warp w owns M-rows [16w,16w+16), i.e. A's column band [.,16w:16w+16).
+// ===========================================================================
+
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B, int accumulate=1>
+__device__ static inline void mma_AtB(D &d, const A &a, const B &b) {
+    KITTENS_CHECK_WARPGROUP
+    using T_AB = typename A::T;
+    KITTENS_SM120_WG_MMA_DTYPE_CHECK(T_AB);
+    // warp w's column band of A: rows [0,K), cols [16w, 16w+16) -> col-layout [K,16]
+    rt<T_AB, A::rows, D::rows, ducks::rt_layout::col> a_w;
+    group<1>::load(a_w, const_cast<A&>(a).template subtile<A::rows, D::rows>({0, (int)warpid()}));
+    rt<T_AB, B::rows, B::cols, ducks::rt_layout::col> b_reg; // [K, N] col
+    group<1>::load(b_reg, b);
+    if constexpr (!accumulate) group<1>::zero(d);
+    group<1>::mma_AtB(d, a_w, b_reg, d);
+}
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B>
+__device__ static inline void mm_AtB(D &d, const A &a, const B &b) {
+    mma_AtB<D, A, B, 0>(d, a, b);
+}
+
+// ===========================================================================
+//  mma_AtBt / mm_AtBt :  D = A^T @ B^T  (A is [K, M] shared, B is [N, K] shared)
+// ===========================================================================
+
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B, int accumulate=1>
+__device__ static inline void mma_AtBt(D &d, const A &a, const B &b) {
+    KITTENS_CHECK_WARPGROUP
+    using T_AB = typename A::T;
+    KITTENS_SM120_WG_MMA_DTYPE_CHECK(T_AB);
+    rt<T_AB, A::rows, D::rows, ducks::rt_layout::col> a_w; // A col band [K,16]
+    group<1>::load(a_w, const_cast<A&>(a).template subtile<A::rows, D::rows>({0, (int)warpid()}));
+    rt<T_AB, B::rows, B::cols, ducks::rt_layout::row> b_reg; // [N, K] row
+    group<1>::load(b_reg, b);
+    if constexpr (!accumulate) group<1>::zero(d);
+    group<1>::mma_AtBt(d, a_w, b_reg, d);
+}
+template<ducks::rt::row_layout D, ducks::st::all A, ducks::st::all B>
+__device__ static inline void mm_AtBt(D &d, const A &a, const B &b) {
+    mma_AtBt<D, A, B, 0>(d, a, b);
+}
+
+// ===========================================================================
+//  Aliases: mma == mma_AB, dot == mma_ABt   (match warpgroup.cuh)
+// ===========================================================================
+
+template<ducks::rt::row_layout D, typename A, ducks::st::all B>
+__device__ static inline void mma(D &d, const A &a, const B &b) { mma_AB(d, a, b); }
+template<ducks::rt::row_layout D, typename A, ducks::st::all B>
+__device__ static inline void mm(D &d, const A &a, const B &b) { mm_AB(d, a, b); }
+template<ducks::rt::row_layout D, typename A, ducks::st::all B>
+__device__ static inline void dot(D &d, const A &a, const B &b) { mma_ABt(d, a, b); }
+
+#undef KITTENS_SM120_WG_MMA_DTYPE_CHECK

--- a/kernels/attention/mha_h100/mha_h100.cu
+++ b/kernels/attention/mha_h100/mha_h100.cu
@@ -17,7 +17,11 @@ template<> struct fwd_attend_ker_tile_dims<64> {
     constexpr static int tile_width = (64);
     constexpr static int qo_height  = (4*16);
     constexpr static int kv_height  = (8*16);
-    constexpr static int stages     = (4); 
+#ifdef KITTENS_SM120
+    constexpr static int stages     = (2); // 99KB smem on GB10 (vs 4 on H100)
+#else
+    constexpr static int stages     = (4);
+#endif
 };
 template<> struct fwd_attend_ker_tile_dims<128> {
     constexpr static int tile_width = (128);

--- a/kernels/common.mk
+++ b/kernels/common.mk
@@ -84,7 +84,11 @@ NVCCFLAGS += -ltorch_python -ltorch_cuda -ltorch_cpu -ltorch -lc10_cuda -lc10
 endif
 
 # Architecture-specific flags
-ifeq ($(ARCH),SM120)
+ifeq ($(ARCH),SM121)
+# GB10 (DGX Spark) is sm_121: reuse the SM120 consumer-Blackwell feature set,
+# but emit native sm_121a SASS (sm_120a cubins will NOT load on sm_121).
+NVCCFLAGS += -DKITTENS_SM120 -gencode arch=compute_121a,code=sm_121a
+else ifeq ($(ARCH),SM120)
 NVCCFLAGS += -DKITTENS_SM120 -gencode arch=compute_120a,code=sm_120a
 else ifeq ($(ARCH),SM103)
 NVCCFLAGS += -DKITTENS_SM103 -gencode arch=compute_103a,code=sm_103a
@@ -95,7 +99,7 @@ NVCCFLAGS += -DKITTENS_SM90 -gencode arch=compute_90a,code=sm_90a
 else ifeq ($(ARCH),SM80)
 NVCCFLAGS += -DKITTENS_SM80 -gencode arch=compute_80,code=sm_80
 else
-$(error Unsupported ARCH: $(ARCH). Please set ARCH to SM80, SM90, SM100, SM103, or SM120.)
+$(error Unsupported ARCH: $(ARCH). Please set ARCH to SM80, SM90, SM100, SM103, SM120, or SM121.)
 endif
 
 all: $(OUT)

--- a/kernels/gemm/bf16_h100/bf16_h100_gemm.cu
+++ b/kernels/gemm/bf16_h100/bf16_h100_gemm.cu
@@ -20,7 +20,11 @@ struct matmul_template {
     static constexpr int M_BLOCK = _M_BLOCK, N_BLOCK = _N_BLOCK, SUPER_M = _SUPER_M;
     using layout    = matmul_layout<M_BLOCK, N_BLOCK>;
     using wide_tile = st_bf<64, 64*N_BLOCK>;
+#ifdef KITTENS_SM120
+    static constexpr int NUM_CONSUMER_WARPS=M_BLOCK*4, INPUT_PIPE_STAGES=2, PRODUCER_BARRIER_ARRIVALS=1; // 99KB smem on GB10
+#else
     static constexpr int NUM_CONSUMER_WARPS=M_BLOCK*4, INPUT_PIPE_STAGES=4, PRODUCER_BARRIER_ARRIVALS=1;
+#endif
     // Helper functions
     template<bool PERISISTENT_GRID=true> __host__ static inline dim3 grid(int M, int N, int K) {
         return dim3(PERISISTENT_GRID ? 132 : M*N/(M_BLOCK*N_BLOCK*layout::base_tile::num_elements));
@@ -212,7 +216,11 @@ int main() {
     // run_benchmark<matmul_template<12>>(4096, 4096, 4096, Rblocks, Cblocks, Rblocks192, Cblocks192);
     int N;
     N = 4096;
+#ifdef KITTENS_SM120
+    run_benchmark<matmul_template<2,2,8>>(N, N, N); // smaller blocks to fit 99KB smem on GB10
+#else
     run_benchmark<matmul_template<2,4,8>>(N, N, N);
+#endif
     // N = 3072;
     // run_benchmark<matmul_template<2,4,8>>(N, N, N);
     // run_benchmark<matmul_template<3,3,8>>(N, N, N);

--- a/kernels/rotary/rotary.cu
+++ b/kernels/rotary/rotary.cu
@@ -24,7 +24,13 @@ template<int _headdim, int _warps> struct rotary_layout {
     struct consumer_state { rt_fl<16, headdim/2> sin, cos; }; // long-resident tiles
 };
 template<int _headdim> struct rotary_template {
+#ifdef KITTENS_SM120
+    // GB10/SM120 has only 99 KB shared memory (vs 227 KB on H100). Halve the
+    // consumer warps and pipeline depth so the LCSF buffers fit.
+    static constexpr int headdim=_headdim, NUM_CONSUMER_WARPS=4, NUM_BLOCKS=1, OUTPUT_PIPE_STAGES=2, INPUT_PIPE_STAGES=2;
+#else
     static constexpr int headdim=_headdim, NUM_CONSUMER_WARPS=8, NUM_BLOCKS=1, OUTPUT_PIPE_STAGES=3, INPUT_PIPE_STAGES=3;
+#endif
     using layout = rotary_layout<headdim, NUM_CONSUMER_WARPS>;
     __device__ static inline void common_setup(common_setup_args<layout> args) {
         if(args.task_iter == 0) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@
 # If you want to run lots of tests without parallel compilation, be prepared
 # to spend a *long* time compiling. (like, HOURS single-threaded.)
 
-# Architecture Selection: Set to SM80, SM90, SM100, SM103, or SM120
+# Architecture Selection: Set to SM80, SM90, SM100, SM103, SM120, or SM121 (GB10)
 ARCH=SM90
 COMP_LEVEL=fast
 
@@ -40,6 +40,10 @@ else ifeq ($(ARCH),SM100)
 NVCCFLAGS+= -gencode arch=compute_100a,code=sm_100a -DKITTENS_SM100 -lcuda -lcudart
 else ifeq ($(ARCH),SM103)
 NVCCFLAGS+= -gencode arch=compute_103a,code=sm_103a -DKITTENS_SM103 -lcuda -lcudart
+else ifeq ($(ARCH),SM121)
+# GB10 (DGX Spark): SM120 feature set, native sm_121a SASS (sm_120a won't load on sm_121).
+# GB10 is single-GPU, so skip the multi-GPU (PGL) tests.
+NVCCFLAGS+= -gencode arch=compute_121a,code=sm_121a -DKITTENS_SM120 -DNUM_GPUS=1 -lcuda -lcudart
 else ifeq ($(ARCH),SM120)
 NVCCFLAGS+= -gencode arch=compute_120a,code=sm_120a -DKITTENS_SM120 -lcuda -lcudart
 endif

--- a/tests/testing_commons/testing_flags.cuh
+++ b/tests/testing_commons/testing_flags.cuh
@@ -129,8 +129,11 @@
 
 /* ----------  MULTI_GPU TEST MACROS  ---------- */
 
-// For fast testing, set it to 2~4
+// For fast testing, set it to 2~4. Override with -DNUM_GPUS=1 on single-GPU
+// machines (e.g. GB10 / DGX Spark) to skip the multi-GPU tests.
+#ifndef NUM_GPUS
 #define NUM_GPUS 2
+#endif
 
 // Macro for testing all the multi-gpu-related tests
 #if defined(TEST_ALL_MULTI_GPU) && NUM_GPUS > 1
@@ -153,6 +156,13 @@
 #define TEST_GROUP_MMA_WARPGROUP_INT32_INT8
 #define TEST_GROUP_MMA_WARPGROUP_INT32_UINT8
 #define TEST_ALL_GROUP_MMA_WARPGROUP_COMPLEX
+#endif
+
+// SM120 warpgroup MMA shim validation: bf16->fp32 only. The warp-level mma.sync
+// path on SM120 has no half->half base for ABt/AtB (and no half->fp32, fp8, int8
+// for these variants), so only the bf16 warpgroup tests are enabled here.
+#if defined(KITTENS_SM120) && defined(TEST_ALL_GROUP_MMA)
+#define TEST_GROUP_MMA_WARPGROUP_FP32_BF16
 #endif
 
 #ifdef TEST_ALL_GROUP_MMA_TENSOR


### PR DESCRIPTION
## Summary

Adds ThunderKittens support for **GB10 / NVIDIA DGX Spark** (`sm_121`, consumer-class Blackwell). GB10 has *neither* Hopper's `wgmma` (SM90) *nor* datacenter Blackwell's `tcgen05`/tensor-memory (SM100/103), and only **99 KB** shared memory/block (vs 227 KB on H100/B200). This PR makes TK's tile primitives, TMA, and warp-level tensor cores work on `sm_121`, and brings H100 WGMMA kernels online through a shim — validated end-to-end on real GB10 hardware.

It reuses the existing `KITTENS_SM120` feature macro (GB10 shares the consumer-Blackwell feature set) and only adds native `sm_121a` codegen — **no new arch macro** is introduced.

## What's in this PR (9 files)

- **WGMMA shim** — `include/ops/group/mma/warpgroup_sm120.cuh` (+ wired into `mma.cuh` under `#ifdef KITTENS_SM120`). Re-exposes the H100 `warpgroup::mma_*` / `mm_*` / `mma`/`mm`/`dot` + `mma_fence`/`mma_commit_group`/`mma_async_wait` surface on SM120 by lowering each call to per-warp `warp::mma.sync`. H100 kernels and the `prototype/` LCF templates compile unchanged.
- **Build targets** — an `SM121` branch in `kernels/common.mk` and `tests/Makefile`: `-DKITTENS_SM120 -gencode arch=compute_121a,code=sm_121a` (native `sm_121a` SASS — `sm_120a` cubins do **not** load on `sm_121`, they fail with `cudaErrorNoKernelImageForDevice`). The test branch also sets `NUM_GPUS=1`.
- **SM120 test gating** — `tests/testing_commons/testing_flags.cuh` enables the **bf16** warpgroup-MMA tests on SM120 and excludes the dtype/feature sets the arch lacks (`tcgen05` tensor tests; fp8/fp16/int8/complex *warpgroup* variants). Warp-level MMA and TMA tests stay on.
- **99 KB shared-memory retuning** — `gemm/bf16_h100`, `attention/mha_h100`, and `rotary` get `#ifdef KITTENS_SM120` blocks shrinking tile sizes / pipeline stages to fit GB10's 99 KB (e.g. gemm `M_BLOCK=2,N_BLOCK=2,INPUT_PIPE_STAGES=2`; rotary `NUM_CONSUMER_WARPS` 8→4, stages 3→2; mha fwd stages 4→2). No algorithmic change.
- **README** — one line under Hardware requirements.

## Design notes

- **Layout correctness.** A 64-row warpgroup output tile is four 16-row bands; warp `w` owns rows `[16w, 16w+16)` — exactly how `group<4>::load` distributes a shared tile and how the WGMMA D-fragment is partitioned. So per-warp `warp::mma` over band `w` reproduces the same register layout WGMMA would. Operand transpose-loads use `group<1>::load` (ldsm).
- **`mma_async_wait` is a real warpgroup barrier, not a no-op.** On H100 it's `wgmma.wait_group.sync.aligned` (warpgroup-wide). The shim's MMA is synchronous per warp, but kernels signal shared-buffer reuse immediately after the wait, so a barrier is still required or warps 1–3 may still be reading A/B from shared when the producer overwrites it (a WAR race). The shim issues `bar.sync (8 + groupid()), 128`.
  - **Reserved named barriers 8–11.** Chosen disjoint from the LCF/LCSF/LCSC prototype templates (ids 13/14/15) and from the kernels' own barriers (`groupid+4` = 4–7; mha's `group<8>` id 10). Kernels combining this shim's MMA with their own named barriers must keep theirs disjoint from `8 + groupid()`.
- **Coverage / limits.** **bf16 only** (enforced by a `static_assert`) — the SM120 warp-level `mma.sync` path lacks the half/fp8/int8 base ops the transposed warpgroup variants would need. The shim is **synchronous** (no WGMMA async-pipeline overlap), so kernels are correct but performance is functional rather than tuned.

## Validation (on real GB10, CUDA 13.0, `sm_121a`)

- **Unit-test suite:** `cd tests && make ARCH=SM121 && ./unit_tests` → **3239/3240 pass**. The single failure is the pre-existing `warp_cmplx_mma_AB` complex-MMA FP-tolerance flake the README already notes — unrelated to this change.
- **`gemm/bf16_h100`:** builds + runs correct on 4096³ (`err max 0.5`, bf16-level), deterministic across runs, ~74 TFLOPs.
- **`attention/mha_h100` forward (D=64):** correct and deterministic vs PyTorch SDPA (0.4–0.6% rel error).
- **`rotary`, `layernorm`:** build and run correct on GB10.
- **End-to-end (Megakernels low-latency Llama, Llama-3.2-1B, batch-1):** the megakernel builds against this TK (via `THUNDERKITTENS_ROOT`) and `diff_test` passes with **logits exact** (max adiff 0.0); ~97 tok/s vs torch eager ~66. The Megakernels-side GB10 changes in the companion PR **HazyResearch/Megakernels#11**, which builds against this branch.

## Not supported on GB10 (out of scope)

- Datacenter-Blackwell `tcgen05` / tensor-memory features → the `*_b200`/`*_b300` and **NVFP4 / MXFP8** GEMM kernels (TK's only fp4/mxfp8 MMA path is `tcgen05`-based).
- Multi-GPU `parallel/*` kernels (GB10 is a single chip).

## Deferred follow-ups

Remaining GB10-eligible H100 kernel ports (each needs the 99 KB retune); `mha_h100` backward & D=128 (compile but hang on GB10 — fwd/D=64 only for now); async-pipeline shim performance; fp8/int8 + NVFP4 shim coverage.

Co-created with Claude Code
