### PR TITLE
Add initial TVM-FFI bindings for Rotary and LayerNorm

### DIFF
--- a/include/pyutils/cuda_utils.cuh
+++ b/include/pyutils/cuda_utils.cuh
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include "kittens.cuh"
+
+namespace kittens {
+namespace detail {
+
+__host__ inline void throw_if_cuda_error(cudaError_t error, const char *operation) {
+    if (error != cudaSuccess)
+        throw std::runtime_error(std::string(operation) + " failed: " +
+            cudaGetErrorName(error) + " (" + std::to_string(static_cast<int>(error)) +
+            "): " + cudaGetErrorString(error));
+}
+
+template <typename Config>
+concept has_min_blocks_per_sm = requires { std::integral_constant<int, int(Config::MIN_BLOCKS_PER_SM)>{}; };
+
+template <typename Config>
+__host__ consteval int min_blocks_per_sm() {
+    if constexpr (has_min_blocks_per_sm<Config>)
+        return Config::MIN_BLOCKS_PER_SM;
+    else
+        return 1;
+}
+
+template <typename Config, typename Globals, auto Kernel>
+__global__
+__launch_bounds__(Config::NUM_THREADS, min_blocks_per_sm<Config>())
+void global_kernel(const __grid_constant__ Globals G) {
+    Kernel(G);
+}
+
+template <typename Config>
+concept static_grid = requires { Config::NUM_BLOCKS; };
+
+template <typename Config>
+concept static_block = requires { Config::NUM_THREADS; };
+
+template <typename Config>
+concept static_dynamic_shared_memory = requires { Config::DYNAMIC_SHARED_MEMORY; };
+
+template <typename Config>
+concept has_pdl_config = requires { { Config::USE_PDL } -> std::convertible_to<bool>; };
+template <typename Config>
+inline constexpr bool use_pdl = false;
+template <typename Config> requires has_pdl_config<Config>
+inline constexpr bool use_pdl<Config> = Config::USE_PDL;
+
+template <typename Config, typename Globals, auto Kernel>
+__host__ static inline void launch_kernel(const Globals &G, cudaStream_t stream) {
+    dim3 grid;
+    if constexpr (static_grid<Config>)
+        grid = dim3{Config::NUM_BLOCKS, 1, 1};
+    else
+        grid = G.grid();
+
+    dim3 block;
+    if constexpr (static_block<Config>)
+        block = dim3{Config::NUM_THREADS, 1, 1};
+    else
+        block = G.block();
+
+    int dynamic_shared_memory;
+    if constexpr (static_dynamic_shared_memory<Config>)
+        dynamic_shared_memory = static_cast<int>(Config::DYNAMIC_SHARED_MEMORY);
+    else
+        dynamic_shared_memory = G.dynamic_shared_memory();
+
+#if defined(KITTENS_SM90)
+    static_assert(Config::CLUSTER_SIZE <= 8, "Cluster size must be less than or equal to 8 for Hopper");
+#elif defined(KITTENS_SM10X) || defined(KITTENS_SM120)
+    static_assert(Config::CLUSTER_SIZE <= 16, "Cluster size must be less than or equal to 16 for Blackwell");
+    if constexpr (Config::CLUSTER_SIZE > 8)
+        throw_if_cuda_error(cudaFuncSetAttribute(global_kernel<Config, Globals, Kernel>, cudaFuncAttributeNonPortableClusterSizeAllowed, 1), "cudaFuncSetAttribute");
+#endif
+    if (dynamic_shared_memory > 0)
+        throw_if_cuda_error(cudaFuncSetAttribute(global_kernel<Config, Globals, Kernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shared_memory), "cudaFuncSetAttribute");
+
+    if constexpr (Config::CLUSTER_SIZE <= 1) {
+        LaunchConfig<false, use_pdl<Config>> launch_config(grid, block, dynamic_shared_memory, stream);
+        throw_if_cuda_error(cudaLaunchKernelEx(launch_config, global_kernel<Config, Globals, Kernel>, G), "cudaLaunchKernelEx");
+    } else {
+        LaunchConfig<true, use_pdl<Config>> launch_config(grid, block, dynamic_shared_memory, stream, Config::CLUSTER_SIZE);
+        throw_if_cuda_error(cudaLaunchKernelEx(launch_config, global_kernel<Config, Globals, Kernel>, G), "cudaLaunchKernelEx");
+    }
+}
+
+} // namespace detail
+} // namespace kittens

--- a/include/pyutils/torchutils.cuh
+++ b/include/pyutils/torchutils.cuh
@@ -4,6 +4,7 @@
 #include <ATen/core/Tensor.h>
 
 #include "kittens.cuh"
+#include "cuda_utils.cuh"
 #include "parallel_tensor.cuh"
 
 #define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
@@ -13,23 +14,7 @@
 namespace kittens {
 namespace py {
 
-template <typename Config>
-concept has_min_blocks_per_sm = requires { std::integral_constant<int, int(Config::MIN_BLOCKS_PER_SM)>{}; };
-
-template <typename Config>
-__host__ consteval int min_blocks_per_sm() {
-    if constexpr(has_min_blocks_per_sm<Config>)
-        return Config::MIN_BLOCKS_PER_SM;
-    else
-        return 1;
-}
-
-template <typename Config, typename Globals, auto Kernel>
-__global__
-__launch_bounds__(Config::NUM_THREADS, min_blocks_per_sm<Config>())
-void global_kernel(const __grid_constant__ Globals G) {
-    Kernel(G);
-}
+using ::kittens::detail::global_kernel;
 
 template <typename Layout, bool TypeCheck = true>
 __host__ static inline void tensor_check(const at::Tensor &t) {
@@ -167,60 +152,9 @@ __host__ static inline void parallel_tensor_check(const T1& first, const Ts&... 
     (_parallel_tensor_check(first, rest), ...);
 }
 
-template <typename Config>
-concept static_grid = requires { Config::NUM_BLOCKS; };
-
-template <typename Config>
-concept static_block = requires { Config::NUM_THREADS; };
-
-template <typename Config>
-concept static_dynamic_shared_memory = requires { Config::DYNAMIC_SHARED_MEMORY; };
-
-template <typename Config>
-concept has_pdl_config = requires { { Config::USE_PDL } -> std::convertible_to<bool>; };
-template <typename Config>
-inline constexpr bool use_pdl = false;
-template <typename Config> requires has_pdl_config<Config>
-inline constexpr bool use_pdl<Config> = Config::USE_PDL;
-
 template <typename Config, typename Globals, auto Kernel>
 __host__ static inline void launch_kernel(const Globals &G) {
-    dim3 grid;
-    if constexpr (static_grid<Config>)
-        grid = dim3{Config::NUM_BLOCKS, 1, 1};
-    else
-        grid = G.grid();
-
-    dim3 block;
-    if constexpr (static_block<Config>)
-        block = dim3{Config::NUM_THREADS, 1, 1};
-    else
-        block = G.block();
-
-    int dynamic_shared_memory;
-    if constexpr (static_dynamic_shared_memory<Config>)
-        dynamic_shared_memory = static_cast<int>(Config::DYNAMIC_SHARED_MEMORY);
-    else
-        dynamic_shared_memory = G.dynamic_shared_memory();
-
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-
-#if defined(KITTENS_SM90)
-    static_assert(Config::CLUSTER_SIZE <= 8, "Cluster size must be less than or equal to 8 for Hopper");
-#elif defined(KITTENS_SM10X) || defined(KITTENS_SM120)
-    static_assert(Config::CLUSTER_SIZE <= 16, "Cluster size must be less than or equal to 16 for Blackwell");
-    if constexpr (Config::CLUSTER_SIZE > 8)
-        CUDACHECK(cudaFuncSetAttribute(global_kernel<Config, Globals, Kernel>, cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
-#endif
-    CUDACHECK(cudaFuncSetAttribute(global_kernel<Config, Globals, Kernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shared_memory));
-
-    if constexpr (Config::CLUSTER_SIZE <= 1) {
-        LaunchConfig<false, use_pdl<Config>> launch_config(grid, block, dynamic_shared_memory, stream);
-        CUDACHECK(cudaLaunchKernelEx(launch_config, global_kernel<Config, Globals, Kernel>, G));
-    } else {
-        LaunchConfig<true, use_pdl<Config>> launch_config(grid, block, dynamic_shared_memory, stream, Config::CLUSTER_SIZE);
-        CUDACHECK(cudaLaunchKernelEx(launch_config, global_kernel<Config, Globals, Kernel>, G));
-    }
+    ::kittens::detail::launch_kernel<Config, Globals, Kernel>(G, at::cuda::getCurrentCUDAStream());
 }
 
 } // namespace py

--- a/include/pyutils/tvm_ffi_utils.cuh
+++ b/include/pyutils/tvm_ffi_utils.cuh
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/cuda/device_guard.h>
+#include <tvm/ffi/extra/dtype.h>
+#include <tvm/ffi/tvm_ffi.h>
+
+#include "kittens.cuh"
+
+namespace kittens {
+namespace tvm_ffi {
+namespace detail {
+
+__host__ inline void check_cuda_device(DLDevice device) {
+  TVM_FFI_CHECK(device.device_type == kDLCUDA, ValueError)
+      << "Expected a CUDA tensor";
+  TVM_FFI_CHECK(device.device_id >= 0, ValueError)
+      << "CUDA device id must be non-negative";
+}
+
+__host__ inline std::uintptr_t tensor_data_address(
+    const ::tvm::ffi::TensorView &tensor
+) {
+  TVM_FFI_CHECK(tensor.data_ptr() != nullptr, ValueError)
+      << "Tensor data pointer must not be null";
+  const std::uintptr_t base =
+      reinterpret_cast<std::uintptr_t>(tensor.data_ptr());
+  TVM_FFI_CHECK(tensor.byte_offset() <=
+                    std::numeric_limits<std::uintptr_t>::max() - base,
+                ValueError)
+      << "Tensor byte offset overflows the data pointer";
+  return base + tensor.byte_offset();
+}
+
+template <typename DType>
+__host__ inline std::uintptr_t validate_tensor(
+    const ::tvm::ffi::TensorView &tensor
+) {
+  check_cuda_device(tensor.device());
+  TVM_FFI_CHECK(tensor.ndim() >= 0 && tensor.ndim() <= 4, ValueError)
+      << "Expected a tensor with 0 to 4 dimensions, got " << tensor.ndim();
+
+  static_assert(std::is_same_v<DType, ::kittens::half> ||
+                    std::is_same_v<DType, ::kittens::bf16> ||
+                    std::is_same_v<DType, float> ||
+                    std::is_same_v<DType, signed char> ||
+                    std::is_same_v<DType, int>,
+                "Unsupported TVM-FFI tensor dtype");
+  constexpr DLDataType expected = ::tvm_ffi::dtype_trait<DType>::value;
+  TVM_FFI_CHECK(tensor.dtype() == expected, TypeError)
+      << "Tensor dtype mismatch: expected " << expected << ", got "
+      << tensor.dtype();
+
+  int64_t element_count = 1;
+  for (int32_t i = 0; i < tensor.ndim(); ++i) {
+    const int64_t dim = tensor.size(i);
+    TVM_FFI_CHECK(dim > 0, ValueError)
+        << "Tensor dimensions must be positive, got " << dim << " at axis "
+        << i;
+    TVM_FFI_CHECK(dim <= std::numeric_limits<int>::max(), ValueError)
+        << "Tensor dimension exceeds int range at axis " << i << ": " << dim;
+    TVM_FFI_CHECK(
+        element_count <= std::numeric_limits<int64_t>::max() / dim,
+        ValueError
+    ) << "Tensor element count exceeds int64 range";
+    element_count *= dim;
+  }
+
+  TVM_FFI_CHECK(tensor.IsContiguous(), ValueError)
+      << "Tensor must be contiguous";
+
+  const std::uintptr_t data = tensor_data_address(tensor);
+  TVM_FFI_CHECK(data % alignof(DType) == 0, ValueError)
+      << "Tensor data pointer is not naturally aligned for its dtype";
+
+  return data;
+}
+
+} // namespace detail
+
+__host__ inline void check_data_alignment(
+    const ::tvm::ffi::TensorView &tensor,
+    std::size_t alignment
+) {
+  detail::check_cuda_device(tensor.device());
+  TVM_FFI_CHECK(
+      alignment != 0 && (alignment & (alignment - 1)) == 0,
+      ValueError
+  ) << "Tensor alignment must be a nonzero power of two";
+  const std::uintptr_t data = detail::tensor_data_address(tensor);
+  TVM_FFI_CHECK(data % alignment == 0, ValueError)
+      << "Tensor data pointer must be aligned to " << alignment << " bytes";
+}
+
+template <typename DType>
+__host__ inline DType *tensor_data_ptr(
+    const ::tvm::ffi::TensorView &tensor
+) {
+  const std::uintptr_t data =
+      detail::validate_tensor<DType>(tensor);
+  return reinterpret_cast<DType *>(data);
+}
+
+template <typename... TensorViews>
+__host__ inline void check_same_device(const ::tvm::ffi::TensorView &first,
+                                       const TensorViews &...rest) {
+  detail::check_cuda_device(first.device());
+  const DLDevice expected = first.device();
+  const auto check_one = [expected](const ::tvm::ffi::TensorView &tensor) {
+    detail::check_cuda_device(tensor.device());
+    const DLDevice actual = tensor.device();
+    TVM_FFI_CHECK(actual.device_type == expected.device_type &&
+                      actual.device_id == expected.device_id,
+                  ValueError)
+        << "All tensors must be on the same CUDA device";
+  };
+  (check_one(rest), ...);
+}
+
+__host__ inline cudaStream_t get_cuda_stream(DLDevice device) {
+  detail::check_cuda_device(device);
+  return static_cast<cudaStream_t>(
+      TVMFFIEnvGetStream(device.device_type, device.device_id));
+}
+
+} // namespace tvm_ffi
+} // namespace kittens

--- a/kernels/common.mk
+++ b/kernels/common.mk
@@ -3,7 +3,7 @@
 #   SRC := kernel.cu
 #   OUT := kernel
 #   CMD := ./kernel
-#   CONFIG := standalone | python | pytorch
+#   CONFIG := standalone | python | pytorch | tvm_ffi
 #   include common.mk
 
 # These should be set by the including Makefile
@@ -11,7 +11,7 @@ ARCH ?= NOT_SET # SM80 | SM90 | SM100 | SM103 | SM120
 SRC ?= NOT_SET # ex. my_kernel.cu
 OUT ?= NOT_SET # ex. _C$(shell python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
 CMD ?= NOT_SET # ex. ./my_kernel, OMP_NUM_THREADS=1 torchrun --nproc_per_node=8 benchmark.py
-CONFIG ?= NOT_SET # standalone | python | pytorch
+CONFIG ?= NOT_SET # standalone | python | pytorch | tvm_ffi
 ifeq ($(ARCH),NOT_SET)
 $(error ARCH is not set. Please set ARCH to SM80, SM90, SM100, SM103, or SM120)
 endif
@@ -25,7 +25,7 @@ ifeq ($(CMD),NOT_SET)
 $(error CMD is not set. Please set CMD to run command)
 endif
 ifeq ($(CONFIG),NOT_SET)
-$(error CONFIG is not set. Please set CONFIG to standalone, python, or pytorch)
+$(error CONFIG is not set. Please set CONFIG to standalone, python, pytorch, or tvm_ffi)
 endif
 
 # Compiler configuration
@@ -81,6 +81,18 @@ NVCCFLAGS += $(PYTHON_INCLUDES) ${PYTHON_LIBDIR} $(PYBIND_INCLUDES)
 NVCCFLAGS += ${PYTORCH_LIBDIR} $(PYTORCH_INCLUDES) 
 NVCCFLAGS += -lpython${PYTHON_VERSION} 
 NVCCFLAGS += -ltorch_python -ltorch_cuda -ltorch_cpu -ltorch -lc10_cuda -lc10
+endif
+
+# TVM-FFI configuration (a regular shared library, not a Python extension)
+ifeq ($(CONFIG),tvm_ffi)
+TVM_FFI_CONFIG ?= tvm-ffi-config
+TVM_FFI_CHECK = $(if $(shell command -v $(TVM_FFI_CONFIG) 2>/dev/null),,$(error tvm-ffi-config was not found. Install it with: python3 -m pip install 'apache-tvm-ffi>=0.1.12,<0.2'))
+TVM_FFI_NVCCFLAGS = $(TVM_FFI_CHECK) \
+	-shared -Xcompiler=-fPIC -Xcompiler=-fvisibility=hidden \
+	$(filter-out -std=c++17,$(shell $(TVM_FFI_CONFIG) --cxxflags)) \
+	$(shell $(TVM_FFI_CONFIG) --ldflags) $(shell $(TVM_FFI_CONFIG) --libs)
+
+$(OUT) ptx: NVCCFLAGS += $(TVM_FFI_NVCCFLAGS)
 endif
 
 # Architecture-specific flags

--- a/kernels/layernorm/Makefile
+++ b/kernels/layernorm/Makefile
@@ -7,6 +7,12 @@ CMD := python benchmark.py # or test_correctness.py
 NVCCFLAGS := -DTORCH_COMPILE
 CONFIG := pytorch
 
+## tvm-ffi mode
+# OUT := layernorm_tvm_ffi.so
+# CMD := python test_tvm_ffi.py
+# NVCCFLAGS := -DTVM_FFI_COMPILE
+# CONFIG := tvm_ffi
+
 # Harness mode
 # OUT := layernorm.out
 # CMD := python gentests.py randn; ./layernorm.out randn.txt

--- a/kernels/layernorm/layernorm.cu
+++ b/kernels/layernorm/layernorm.cu
@@ -1,4 +1,5 @@
 #include "kittens.cuh"
+#include "pyutils/cuda_utils.cuh"
 #include <cooperative_groups.h>
 #include <curand_kernel.h>
 #include <cuda/semaphore>
@@ -166,7 +167,8 @@ void dispatch_layernorm(
     bf16 *d_o_resid,
     float dropout_p,
     size_t B, 
-    size_t N
+    size_t N,
+    cudaStream_t stream = nullptr
 ) {
     constexpr size_t D = 1024;
 
@@ -199,15 +201,18 @@ void dispatch_layernorm(
     n_tile_size, n_per_tile};
 
     unsigned long mem_size = 25480; 
-    cudaFuncSetAttribute(
-        layernorm_tk<D>,
-        cudaFuncAttributeMaxDynamicSharedMemorySize,
-        mem_size
+    kittens::detail::throw_if_cuda_error(
+        cudaFuncSetAttribute(
+            layernorm_tk<D>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize,
+            mem_size
+        ),
+        "cudaFuncSetAttribute"
     );
 
     dim3 grid(n_tile_size, B, 1);
-    layernorm_tk<D><<<grid,NUM_THREADS,mem_size>>>(g, n_per_tile);
-    cudaDeviceSynchronize();
+    layernorm_tk<D><<<grid,NUM_THREADS,mem_size,stream>>>(g, n_per_tile);
+    kittens::detail::throw_if_cuda_error(cudaGetLastError(), "layernorm kernel launch");
 }
 
 
@@ -255,21 +260,85 @@ std::tuple<at::Tensor, at::Tensor> fused_layernorm(
     bf16* d_norm_weight_bf = reinterpret_cast<bf16*>(norm_weight_ptr);
     bf16 *d_o = reinterpret_cast<bf16*>(out.data_ptr<c10::BFloat16>());
     bf16 *d_o_resid = reinterpret_cast<bf16*>(out_resid.data_ptr<c10::BFloat16>());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
     dispatch_layernorm(
         d_x_bf, d_residual_bf, 
         d_norm_weight_bf, d_norm_bias_bf, 
         d_o, d_o_resid, dropout_p,
-        (size_t)b, (size_t)n
+        (size_t)b, (size_t)n, stream
     );
-    CHECK_CUDA_ERROR(cudaGetLastError());
 
     return std::make_tuple(out, out_resid);
 }
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("fused_layernorm", fused_layernorm, "LayerNorm TK. Takes tensors (x, residual, norm_weight, norm_bias, dropout_p). x, residual, norm_weight, norm_bias are bf16. dropout_p is float. Returns (B, H, N, 128) in bf16.");
 }
+#elif defined(TVM_FFI_COMPILE)
+#include "pyutils/tvm_ffi_utils.cuh"
+
+namespace {
+
+// Caller-owned output buffers must not overlap each other or any input tensor.
+// Violating this precondition results in undefined behavior.
+void TkLayernorm(tvm::ffi::TensorView output,
+                 tvm::ffi::TensorView output_residual,
+                 tvm::ffi::TensorView input,
+                 tvm::ffi::TensorView residual,
+                 tvm::ffi::TensorView weight,
+                 tvm::ffi::TensorView bias) {
+    kittens::tvm_ffi::check_same_device(
+        output, output_residual, input, residual, weight, bias
+    );
+    TVM_FFI_CHECK(output.ndim() == 3 && output_residual.ndim() == 3 &&
+                      input.ndim() == 3 && residual.ndim() == 3,
+                  ValueError)
+        << "tk_layernorm expects output tensors and inputs to be 3-dimensional";
+    TVM_FFI_CHECK(weight.ndim() == 1 && bias.ndim() == 1, ValueError)
+        << "tk_layernorm expects weight and bias to be 1-dimensional";
+    for (int axis = 0; axis < input.ndim(); ++axis) {
+        TVM_FFI_CHECK(output.size(axis) == input.size(axis) &&
+                          output_residual.size(axis) == input.size(axis) &&
+                          residual.size(axis) == input.size(axis),
+                      ValueError)
+            << "output and residual shapes must match input at axis " << axis;
+    }
+    TVM_FFI_CHECK(input.size(2) == 1024, ValueError)
+        << "tk_layernorm expects hidden dimension 1024";
+    TVM_FFI_CHECK(weight.size(0) == 1024 && bias.size(0) == 1024, ValueError)
+        << "tk_layernorm expects weight and bias length 1024";
+    TVM_FFI_CHECK(input.size(1) % 16 == 0, ValueError)
+        << "tk_layernorm expects sequence length to be a multiple of 16";
+
+    bf16 *output_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(output);
+    bf16 *output_residual_ptr =
+        kittens::tvm_ffi::tensor_data_ptr<bf16>(output_residual);
+    bf16 *input_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(input);
+    bf16 *residual_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(residual);
+    bf16 *weight_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(weight);
+    bf16 *bias_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(bias);
+
+    kittens::tvm_ffi::check_data_alignment(output, 16);
+    kittens::tvm_ffi::check_data_alignment(output_residual, 16);
+    kittens::tvm_ffi::check_data_alignment(input, 16);
+    kittens::tvm_ffi::check_data_alignment(residual, 16);
+    kittens::tvm_ffi::check_data_alignment(weight, 16);
+    kittens::tvm_ffi::check_data_alignment(bias, 16);
+
+    tvm::ffi::CUDADeviceGuard guard(input.device().device_id);
+    cudaStream_t stream = kittens::tvm_ffi::get_cuda_stream(input.device());
+    dispatch_layernorm(
+        input_ptr, residual_ptr,
+        weight_ptr, bias_ptr,
+        output_ptr, output_residual_ptr,
+        0.0f, static_cast<size_t>(input.size(0)),
+        static_cast<size_t>(input.size(1)), stream
+    );
+}
+
+} // namespace
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(tk_layernorm, TkLayernorm);
 #else
 #include "harness.impl"
 #endif
-

--- a/kernels/layernorm/test_tvm_ffi.py
+++ b/kernels/layernorm/test_tvm_ffi.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+import tvm_ffi
+
+
+B, N, D = 2, 16, 1024
+
+
+mod = tvm_ffi.load_module(
+    str(Path(__file__).with_name("layernorm_tvm_ffi.so").resolve())
+)
+torch.manual_seed(0)
+x = torch.randn(B, N, D, device="cuda", dtype=torch.bfloat16)
+residual = torch.randn_like(x)
+weight = torch.randn(D, device="cuda", dtype=torch.bfloat16)
+bias = torch.randn(D, device="cuda", dtype=torch.bfloat16)
+output = torch.empty_like(x)
+output_residual = torch.empty_like(x)
+
+mod.tk_layernorm(output, output_residual, x, residual, weight, bias)
+torch.cuda.synchronize()
+
+expected_residual = x + residual
+expected = F.layer_norm(
+    expected_residual.float(), (D,), weight.float(), bias.float(), 1e-5
+).to(torch.bfloat16)
+torch.testing.assert_close(output_residual, expected_residual, rtol=0.0, atol=0.0)
+torch.testing.assert_close(output, expected, rtol=0.05, atol=0.1)
+print("TVM-FFI LayerNorm test passed")

--- a/kernels/rotary/Makefile
+++ b/kernels/rotary/Makefile
@@ -1,14 +1,19 @@
 ARCH := SM90
+SRC := rotary.cu
 
 # PyTorch extension mode
-SRC := rotary.cu
 OUT := _C$(shell python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
 CMD := python benchmark.py # or test_correctness.py
 NVCCFLAGS := -DTORCH_COMPILE
 CONFIG := pytorch
 
+# tvm-ffi mode
+# OUT := rotary_tvm_ffi.so
+# CMD := python test_tvm_ffi.py
+# NVCCFLAGS := -DTVM_FFI_COMPILE
+# CONFIG := tvm_ffi
+
 # Standalone mode
-# SRC := rotary.cu
 # OUT := rotary.out
 # CMD := python gentests.py randn; ./rotary.out randn.txt
 # CONFIG := standalone

--- a/kernels/rotary/rotary.cu
+++ b/kernels/rotary/rotary.cu
@@ -1,5 +1,6 @@
 #include "kittens.cuh"
 #include "prototype.cuh"
+#include "pyutils/cuda_utils.cuh"
 
 #ifdef TORCH_COMPILE
 #define TK_COMPILE_FUSED_ROTARY
@@ -111,17 +112,14 @@ template<int _headdim> struct rotary_template {
     };
 };
 
-#ifdef TK_COMPILE_FUSED_ROTARY
-#include "pyutils/torchutils.cuh"
-#include <iostream>
-#include <ATen/Functions.h>
 template<int ATTN_D>
 void dispatch_fused_rotary(
     bf16 * d_o,
     bf16 * d_x,
     bf16 * d_sin_in,
     bf16 * d_cos_in,
-    const int ATTN_B, const int ATTN_H, const int ATTN_N
+    const int ATTN_B, const int ATTN_H, const int ATTN_N,
+    cudaStream_t stream = nullptr
 ) {
 
     using rope_t = rotary_template<ATTN_D>;
@@ -139,11 +137,20 @@ void dispatch_fused_rotary(
 
     unsigned long mem_size = (MAX_SHARED_MEMORY-2048);
     constexpr int ROWS_PER_BLOCK = rope_t::NUM_CONSUMER_WARPS * rope_t::layout::seq_tile::rows;
-    cudaFuncSetAttribute(prototype::lcsf::kernel<rope_t>, cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    kittens::detail::throw_if_cuda_error(
+        cudaFuncSetAttribute(prototype::lcsf::kernel<rope_t>, cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size),
+        "cudaFuncSetAttribute"
+    );
     dim3 grid((ATTN_N+ROWS_PER_BLOCK-1)/ROWS_PER_BLOCK, (ATTN_B+BATCHES_PER_BLOCK-1)/BATCHES_PER_BLOCK);
     dim3 block(kittens::prototype::detail::NUM_THREADS_v<rope_t>);
-    kittens::prototype::lcsf::kernel<rope_t><<<grid, block, mem_size>>>(g); 
+    kittens::prototype::lcsf::kernel<rope_t><<<grid, block, mem_size, stream>>>(g);
+    kittens::detail::throw_if_cuda_error(cudaGetLastError(), "rotary kernel launch");
 }
+
+#ifdef TK_COMPILE_FUSED_ROTARY
+#include "pyutils/torchutils.cuh"
+#include <iostream>
+#include <ATen/Functions.h>
 
 at::Tensor fused_rotary(
     const at::Tensor x,
@@ -179,6 +186,7 @@ at::Tensor fused_rotary(
     bf16 *d_sin_in = reinterpret_cast<bf16*>(sin_in_bf16);
     bf16 *d_cos_in = reinterpret_cast<bf16*>(cos_in_bf16);
     bf16 *d_out = reinterpret_cast<bf16*>(out_bf16);
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
     if(x.size(3) == 64) {
         dispatch_fused_rotary<64>(
@@ -186,7 +194,7 @@ at::Tensor fused_rotary(
             d_x,
             d_sin_in,
             d_cos_in, 
-            B, H, N
+            B, H, N, stream
         );
     }
     else {
@@ -195,16 +203,94 @@ at::Tensor fused_rotary(
             d_x,
             d_sin_in,
             d_cos_in, 
-            B, H, N
+            B, H, N, stream
         );
     }
 
-    CHECK_CUDA_ERROR(cudaGetLastError());
     return out;
 }
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("fused_rotary", fused_rotary, "Rotary TK. Takes tensors (x, cos_in, sin_in). All tensors are bf16. Returns (B, H, N, 128) in bf16.");
 }
+#elif defined(TVM_FFI_COMPILE)
+#include "pyutils/tvm_ffi_utils.cuh"
+
+namespace {
+
+void check_matching_shape(const tvm::ffi::TensorView &output,
+                          const tvm::ffi::TensorView &input) {
+  TVM_FFI_CHECK(output.ndim() == input.ndim(), ValueError)
+      << "Output and input must have the same rank";
+  for (int32_t axis = 0; axis < input.ndim(); ++axis) {
+    TVM_FFI_CHECK(output.size(axis) == input.size(axis), ValueError)
+        << "Output and input shape mismatch at axis " << axis;
+  }
+}
+
+// The caller-owned output buffer must not overlap any input tensor.
+// Violating this precondition results in undefined behavior.
+void TkRotary(tvm::ffi::TensorView output, tvm::ffi::TensorView input,
+              tvm::ffi::TensorView cos, tvm::ffi::TensorView sin) {
+  kittens::tvm_ffi::check_same_device(output, input, cos, sin);
+  TVM_FFI_CHECK(input.ndim() == 4, ValueError)
+      << "tk_rotary expects input to be 4-dimensional";
+  TVM_FFI_CHECK(output.ndim() == 4, ValueError)
+      << "tk_rotary expects output to be 4-dimensional";
+  TVM_FFI_CHECK(cos.ndim() == 2 && sin.ndim() == 2, ValueError)
+      << "tk_rotary expects cos and sin to be 2-dimensional";
+  check_matching_shape(output, input);
+
+  constexpr DLDataType expected_dtype{kDLBfloat, 16, 1};
+  TVM_FFI_CHECK(
+      output.dtype() == expected_dtype && input.dtype() == expected_dtype &&
+          cos.dtype() == expected_dtype && sin.dtype() == expected_dtype,
+      TypeError)
+      << "tk_rotary supports only bfloat16 tensors";
+
+  const int64_t sequence_length = input.size(2);
+  const int64_t head_dimension = input.size(3);
+  TVM_FFI_CHECK(sequence_length % 16 == 0, ValueError)
+      << "tk_rotary expects the sequence length to be a multiple of 16";
+  TVM_FFI_CHECK(head_dimension == 64 || head_dimension == 128, ValueError)
+      << "tk_rotary expects head dimension 64 or 128";
+  TVM_FFI_CHECK(cos.size(0) == sequence_length &&
+                    sin.size(0) == sequence_length,
+                ValueError)
+      << "cos and sin sequence lengths must match input";
+  TVM_FFI_CHECK(cos.size(1) == head_dimension / 2 &&
+                    sin.size(1) == head_dimension / 2,
+                ValueError)
+      << "cos and sin widths must be half the input head dimension";
+
+  bf16 *output_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(output);
+  bf16 *input_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(input);
+  bf16 *cos_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(cos);
+  bf16 *sin_ptr = kittens::tvm_ffi::tensor_data_ptr<bf16>(sin);
+
+  kittens::tvm_ffi::check_data_alignment(output, 16);
+  kittens::tvm_ffi::check_data_alignment(input, 16);
+  kittens::tvm_ffi::check_data_alignment(cos, 16);
+  kittens::tvm_ffi::check_data_alignment(sin, 16);
+
+  tvm::ffi::CUDADeviceGuard guard(input.device().device_id);
+  cudaStream_t stream = kittens::tvm_ffi::get_cuda_stream(input.device());
+  if (head_dimension == 64) {
+    dispatch_fused_rotary<64>(
+      output_ptr, input_ptr, sin_ptr, cos_ptr,
+      static_cast<int>(input.size(0)), static_cast<int>(input.size(1)),
+      static_cast<int>(sequence_length), stream);
+  }
+  else {
+    dispatch_fused_rotary<128>(
+      output_ptr, input_ptr, sin_ptr, cos_ptr,
+      static_cast<int>(input.size(0)), static_cast<int>(input.size(1)),
+      static_cast<int>(sequence_length), stream);
+  }
+}
+
+} // namespace
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(tk_rotary, TkRotary);
 #else
 #include "harness.impl"
 #endif

--- a/kernels/rotary/test_tvm_ffi.py
+++ b/kernels/rotary/test_tvm_ffi.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import torch
+import tvm_ffi
+
+
+B, H, N = 2, 3, 144
+
+
+mod = tvm_ffi.load_module(
+    str(Path(__file__).with_name("rotary_tvm_ffi.so").resolve())
+)
+torch.manual_seed(0)
+
+for D in (64, 128):
+    x = torch.randn(B, H, N, D, device="cuda", dtype=torch.bfloat16)
+    positions = torch.arange(N, device="cuda", dtype=torch.float32)
+    inv_freq = 1.0 / (
+        10000
+        ** (torch.arange(0, D, 2, device="cuda", dtype=torch.float32) / D)
+    )
+    frequencies = torch.outer(positions, inv_freq)
+    cos = frequencies.cos().to(torch.bfloat16)
+    sin = frequencies.sin().to(torch.bfloat16)
+    output = torch.empty_like(x)
+
+    mod.tk_rotary(output, x, cos, sin)
+    torch.cuda.synchronize()
+
+    x1, x2 = x.float().chunk(2, dim=-1)
+    expected = torch.cat(
+        (
+            x1 * cos.float()[None, None] - x2 * sin.float()[None, None],
+            x2 * cos.float()[None, None] + x1 * sin.float()[None, None],
+        ),
+        dim=-1,
+    ).to(torch.bfloat16)
+    torch.testing.assert_close(output, expected, rtol=0.02, atol=0.02)
+
+print("TVM-FFI rotary test passed")


### PR DESCRIPTION
This PR adds TVM-FFI bindings for Rotary and LayerNorm. The scope is limited to these two kernels so we can gather early feedback before expanding support.

CUDA launch logic shared by the PyTorch and TVM-FFI paths has been moved into utility headers. TVM-FFI removes the need for PyTorch-specific bindings, but this PR keeps both binding paths during the initial integration.

Part of #176 