### PR TITLE
Implemented DSV4 CSA block compression kernel on H100

### DIFF
--- a/kernels/csa/compression_h100/Makefile
+++ b/kernels/csa/compression_h100/Makefile
@@ -1,0 +1,15 @@
+ARCH := SM90
+SRC := correctness.cu
+OUT := correctness.out
+CMD := python gentests.py randn; ./correctness.out randn_compression_test.txt
+CONFIG := standalone
+include ../../common.mk
+
+# Timing sweep (NUM_WORKERS x C_CHUNK x INPUT_PIPE_STAGES) -- see benchmark.cu.
+benchmark.out: benchmark.cu
+	$(NVCC) benchmark.cu $(NVCCFLAGS) -o benchmark.out
+
+benchmark: benchmark.out
+	./benchmark.out
+
+.PHONY: benchmark

--- a/kernels/csa/compression_h100/benchmark.cu
+++ b/kernels/csa/compression_h100/benchmark.cu
@@ -1,0 +1,234 @@
+// Timing sweep for the CSA block compression kernel over (NUM_WORKERS, C_CHUNK,
+// INPUT_PIPE_STAGES). Every combo below fits H100's per-SM shared-memory budget (~230912 bytes)
+// and respects NUM_WORKERS % 4 == 0, C_CHUNK <= 256 (TMA's unswizzled-tile-width cap).
+#include "compression_h100.cuh"
+
+#include <iostream>
+#include <chrono>
+#include <string>
+#include <vector>
+#include <random>
+#include <limits>
+
+struct bench_data {
+    std::vector<fp8e4m3> value_a, value_b, score_a, score_b;
+    std::vector<bf16> bias_a, bias_b;
+};
+struct bench_best {
+    double us   = std::numeric_limits<double>::max();
+    double gbps = 0;
+    std::string desc;
+};
+
+static std::vector<fp8e4m3> random_fp8e4m3(size_t n, std::mt19937 &rng) {
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<fp8e4m3> out(n);
+    for (size_t i = 0; i < n; i++) out[i] = fp8e4m3(dist(rng));
+    return out;
+}
+static std::vector<bf16> random_bf16(size_t n, std::mt19937 &rng) {
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<bf16> out(n);
+    for (size_t i = 0; i < n; i++) out[i] = __float2bfloat16(dist(rng));
+    return out;
+}
+
+template<int C, int C_CHUNK, int M, int NUM_WORKERS, int PIPE>
+void benchmark_one(int B, int N, const bench_data &data, bench_best &best) {
+    using ker    = compression_template<C, C_CHUNK, M, NUM_WORKERS, PIPE>;
+    using layout = typename ker::layout;
+    int num_blocks = N / M;
+
+    size_t value_elems = (size_t)B * N * C;
+    size_t bias_elems  = (size_t)M * C;
+    size_t out_elems   = (size_t)B * num_blocks * C;
+
+    fp8e4m3 *d_value_a, *d_value_b, *d_score_a, *d_score_b;
+    bf16 *d_bias_a, *d_bias_b, *d_compressed;
+    cudaMalloc(&d_value_a, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_value_b, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_score_a, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_score_b, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_bias_a,  bias_elems  * sizeof(bf16));
+    cudaMalloc(&d_bias_b,  bias_elems  * sizeof(bf16));
+    cudaMalloc(&d_compressed, out_elems * sizeof(bf16));
+    cudaMemcpy(d_value_a, data.value_a.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_value_b, data.value_b.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_score_a, data.score_a.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_score_b, data.score_b.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_bias_a,  data.bias_a.data(),  bias_elems  * sizeof(bf16), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_bias_b,  data.bias_b.data(),  bias_elems  * sizeof(bf16), cudaMemcpyHostToDevice);
+
+    typename layout::block_global Va(d_value_a, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::block_global Vb(d_value_b, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::block_global Sa(d_score_a, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::block_global Sb(d_score_b, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::bias_global  Ba(d_bias_a,  nullptr,   nullptr, nullptr,   nullptr);
+    typename layout::bias_global  Bb(d_bias_b,  nullptr,   nullptr, nullptr,   nullptr);
+    typename layout::out_global   Og(d_compressed, (size_t)B, nullptr, (size_t)num_blocks, nullptr);
+    typename layout::globals globals = {Va, Vb, Sa, Sb, Ba, Bb, Og, /*chunk_idx=*/0};
+
+    unsigned long mem_size = kittens::MAX_SHARED_MEMORY - 2000;
+    cudaFuncSetAttribute(prototype::lcf::kernel<ker>, cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    cudaGetLastError(); // clear, checked properly below
+
+    constexpr int BLOCK_SIZE = prototype::detail::NUM_THREADS_v<ker>;
+    dim3 grid(132, 1, 1);
+
+    constexpr int WARMUP = 5;
+    constexpr int ITERS  = 20;
+
+    auto run_one_pass = [&]() {
+        for (int chunk_idx = 0; chunk_idx < layout::NUM_CHUNKS; chunk_idx++) {
+            globals.chunk_idx = chunk_idx;
+            prototype::lcf::kernel<ker><<<grid, BLOCK_SIZE, mem_size>>>(globals);
+        }
+    };
+
+    for (int i = 0; i < WARMUP; i++) run_one_pass();
+    cudaDeviceSynchronize();
+
+    const auto start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < ITERS; i++) run_one_pass();
+    cudaDeviceSynchronize();
+    const auto finish = std::chrono::high_resolution_clock::now();
+
+    cudaError_t err = cudaGetLastError();
+    double avg_us = std::chrono::duration_cast<std::chrono::microseconds>(finish - start).count() / (double)ITERS;
+
+    // Total bytes moved per full pass (all NUM_CHUNKS launches together): the 4 input
+    // tensors (fp8e4m3, 1 byte/elem) read once each across their full width, plus the
+    // output (bf16, 2 bytes/elem) written once.
+    double bytes_per_pass = 4.0 * value_elems * sizeof(fp8e4m3) + (double)out_elems * sizeof(bf16);
+    double gbps = (bytes_per_pass / 1e9) / (avg_us / 1e6);
+
+    std::cout << "NUM_WORKERS=" << NUM_WORKERS << " C_CHUNK=" << C_CHUNK << " PIPE=" << PIPE
+               << " (NUM_CHUNKS=" << layout::NUM_CHUNKS << ") -> "
+               << avg_us << " us/pass, " << gbps << " GB/s";
+    if (err != cudaSuccess) {
+        std::cout << "  [ERROR: " << cudaGetErrorString(err) << "]";
+    } else if (avg_us < best.us) {
+        best.us   = avg_us;
+        best.gbps = gbps;
+        best.desc = "NUM_WORKERS=" + std::to_string(NUM_WORKERS) +
+                    " C_CHUNK=" + std::to_string(C_CHUNK) +
+                    " PIPE=" + std::to_string(PIPE);
+    }
+    std::cout << "\n";
+
+    cudaFree(d_value_a); cudaFree(d_value_b); cudaFree(d_score_a); cudaFree(d_score_b);
+    cudaFree(d_bias_a);  cudaFree(d_bias_b);  cudaFree(d_compressed);
+}
+
+int main() {
+    constexpr int C_FULL = 512, M = 4;
+    constexpr int B = 8, N = 32768;
+
+    std::cout << "Sweeping NUM_WORKERS x C_CHUNK x INPUT_PIPE_STAGES, C=" << C_FULL
+              << " M=" << M << " B=" << B << " N=" << N << "\n\n";
+
+    std::mt19937 rng(42);
+    size_t value_elems = (size_t)B * N * C_FULL;
+    size_t bias_elems  = (size_t)M * C_FULL;
+    bench_data data{
+        random_fp8e4m3(value_elems, rng), random_fp8e4m3(value_elems, rng),
+        random_fp8e4m3(value_elems, rng), random_fp8e4m3(value_elems, rng),
+        random_bf16(bias_elems, rng), random_bf16(bias_elems, rng),
+    };
+    bench_best best;
+
+    benchmark_one<C_FULL, 32, M, 4, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 4, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 4, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 4, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 4, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 4, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 4, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 4, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 4, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 4, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 4, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 4, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 4, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 4, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 4, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 4, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 8, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 8, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 8, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 8, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 8, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 8, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 8, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 8, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 8, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 8, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 8, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 8, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 8, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 8, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 8, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 12, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 12, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 12, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 12, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 12, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 12, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 12, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 12, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 12, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 12, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 12, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 12, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 12, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 12, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 16, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 16, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 16, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 16, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 16, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 16, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 16, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 16, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 16, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 16, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 16, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 16, 1>(B, N, data, best);
+
+    benchmark_one<C_FULL, 32, M, 20, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 20, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 20, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 20, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 20, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 20, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 20, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 20, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 20, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 20, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 20, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 24, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 24, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 24, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 24, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 24, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 24, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 24, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 24, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 24, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 24, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 24, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 28, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 28, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 28, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 32, M, 28, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 28, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 28, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 28, 3>(B, N, data, best);
+    benchmark_one<C_FULL, 64, M, 28, 4>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 28, 1>(B, N, data, best);
+    benchmark_one<C_FULL, 128, M, 28, 2>(B, N, data, best);
+    benchmark_one<C_FULL, 256, M, 28, 1>(B, N, data, best);
+
+    std::cout << "\nBEST: " << best.desc << " -> " << best.us << " us/pass, " << best.gbps << " GB/s\n";
+    return 0;
+}

--- a/kernels/csa/compression_h100/compression_h100.cuh
+++ b/kernels/csa/compression_h100/compression_h100.cuh
@@ -1,0 +1,279 @@
+/*
+    CSA block compression: averaging groups of tokens into fewer, weighted rows.
+
+    Dimensions used in the shapes below:
+      - B : batch size
+      - N : sequence length
+      - C : channel width
+      - M : block size
+
+    Input (global memory) {gm}:
+      - value_a, value_b : [B, N, C] fp8e4m3
+      - score_a, score_b : [B, N, C] fp8e4m3
+      - bias_a,  bias_b  : [M, C]    bf16
+
+    Output (global memory) {gm}:
+      - compressed : [B, N/M, C] bf16
+
+    Algorithm:
+    We have a sequence of N token rows, each C numbers wide, and we want to shrink it down
+    to N/M rows by combining every M tokens into one. To build output row i:
+
+      - Take M tokens: the "a" group, tokens [i*M, i*M+M).
+      - Also take the M tokens right before it: the "b" group, tokens [(i-1)*M, i*M).
+
+            blocks of M tokens, left to right along the sequence:
+
+                0 ... [ block i-2 ] [ block i-1 ] [ block i ] [ block i+1 ] ... N
+                                        |             |
+                                       "b"           "a"
+                                  group for      group for
+                                  output i       output i
+                                        \_____________/
+                                              |
+                                              v
+                                        output row i
+
+      - Each of these 2M tokens carries two things: a "value" and a "score" .
+        A learned per-position bonus (the "bias") is added to each score first.
+        For position p = 0 .. M-1 within a block:
+
+            za[p] {rm} = score_a[p] {sm} + bias_a[p] {sm}     | weight input, p-th token of the "a" group
+            zb[p] {rm} = score_b[p] {sm} + bias_b[p] {sm}     | weight input, p-th token of the "b" group
+
+      - Turn all 2M scores into weights that add up to 1 (bigger score means bigger
+        weight), done separately for each of the C numbers in a row. For p = 0 .. M-1:
+
+            Sa[p] {rm} = exp(za[p] {rm}) / ( sum_q exp(za[q] {rm}) + sum_q exp(zb[q] {rm}) )   | shared denominator
+            Sb[p] {rm} = exp(zb[p] {rm}) / ( sum_q exp(za[q] {rm}) + sum_q exp(zb[q] {rm}) )   | over all 2M tokens
+
+        Sa and Sb sharing one denominator is what makes this a single softmax over all 2M
+        tokens together, not two separate M-token softmaxes!
+
+      - Multiply every token's value by its own weight and add them all up. That sum is
+        output row i, for p = 0 .. M-1 (out_c is this worker's own accumulator -- see
+        consumer_state::out_c in the code below):
+
+            out_c {rm} = sum_p Sa[p] {rm} * value_a[p] {sm}  +  sum_p Sb[p] {rm} * value_b[p] {sm}
+
+    The very first output row (i=0) has no "b" group before the start of the sequence, so
+    that half is simply left out for that one row: Sa is then normalized using only za,
+    and the "b" term above drops out entirely.
+
+            out_c {rm} = sum_p Sa[p] {rm} * value_a[p] {sm}     | i=0 case: "b" term dropped
+
+    [.]
+
+    NUM_WORKERS output rows are computed side by side per task. C_CHUNK: a single kernel
+    launch only computes a C_CHUNK-wide slice of the full C channels (TMA's unswizzled-tile
+    width cap is smaller than C); the host launches the kernel C/C_CHUNK times
+    (globals.chunk_idx) to cover the whole width.
+
+*/
+#pragma once
+#include "kittens.cuh"
+#include "prototype.cuh"
+
+using namespace kittens;
+using namespace kittens::prototype;
+using namespace kittens::prototype::lcf;
+
+template<int C, int C_CHUNK, int M, int _NUM_WORKERS=4>
+struct compression_layout {
+    static_assert(C_CHUNK % 32 == 0, "C_CHUNK must be a multiple of 32 so it divides evenly across a warp's 32 lanes");
+    static_assert(C % C_CHUNK == 0, "C must be a whole number of C_CHUNK-wide slices");
+    static constexpr int NUM_WORKERS = _NUM_WORKERS;
+    static constexpr int NUM_CHUNKS  = C / C_CHUNK;
+
+    // M rows x C_CHUNK cols, unswizzled: M=4 is below TK's normal 16-row tile floor, and
+    // disabling swizzling is the one tile mechanism that allows a smaller row count.
+
+    using block_tile = st<fp8e4m3, M, C_CHUNK, false>;
+    using bias_tile  = st<bf16, M, C_CHUNK, false>;
+
+    using block_global = kittens::gl<fp8e4m3, -1, 1, -1, C, block_tile>; // value_a/b, score_a/b: [B,1,N,C]
+    using bias_global  = kittens::gl<bf16, 1, 1, M, C, bias_tile>;       // bias_a/b: [1,1,M,C]
+    using out_global   = kittens::gl<bf16, -1, 1, -1, C>;                // compressed: [B,1,N/M,C]
+
+    struct globals {
+        block_global value_a, value_b, score_a, score_b;
+        bias_global  bias_a,  bias_b;
+        out_global   compressed;
+        int chunk_idx; // which C_CHUNK-wide column-tile this launch handles, 0..NUM_CHUNKS-1
+    };
+    struct input_block {
+        block_tile value_a[NUM_WORKERS], value_b[NUM_WORKERS];
+        block_tile score_a[NUM_WORKERS], score_b[NUM_WORKERS];
+    };
+    struct scratch_block {
+        bias_tile bias_a, bias_b; // loaded once (task_iter == 0), reused by every task thereafter
+    };
+    struct common_state {
+        int batch;
+        int block_base; // first of up to NUM_WORKERS output-block indices this task handles
+        int num_blocks; // N/M for this batch element
+    };
+    struct consumer_state {
+        // Plain per-lane register array, not a TK tile type: TK's reductions need
+        // swizzled tiles, which M=4 rules out (see block_tile above).
+        static constexpr int LANE_CHANNELS = C_CHUNK / 32;
+        float out_c[LANE_CHANNELS];
+    };
+};
+
+template<int C, int C_CHUNK, int M, int NUM_WORKERS=4, int _INPUT_PIPE_STAGES=2>
+struct compression_template {
+    using layout = compression_layout<C, C_CHUNK, M, NUM_WORKERS>;
+    static constexpr int NUM_CONSUMER_WARPS = NUM_WORKERS; // one warp per worker, one worker per output row
+    static constexpr int INPUT_PIPE_STAGES  = _INPUT_PIPE_STAGES;
+
+    __device__ static inline void common_setup(common_setup_args<layout> args) {
+        int num_blocks       = args.globals.compressed.rows();
+        int tasks_per_batch  = (num_blocks + NUM_WORKERS - 1) / NUM_WORKERS;
+        int task_id          = gridDim.x * args.task_iter + blockIdx.x;
+
+        args.common.batch      = task_id / tasks_per_batch;
+        int task_in_batch      = task_id - args.common.batch * tasks_per_batch;
+        args.common.block_base = task_in_batch * NUM_WORKERS;
+        args.common.num_blocks = num_blocks;
+
+        args.num_iters = (args.common.batch < args.globals.compressed.batch()) ? 1 : -1;
+    }
+
+    struct producer {
+        __device__ static inline void setup(producer_setup_args<layout> args) {
+            // Shrinks producer registers so consumer::setup can claim the freed space.
+            warpgroup::producer_registers();
+
+            // bias_a/b never change across the whole launch
+            if (args.task_iter == 0) {
+                warpgroup::load(args.scratch.bias_a, args.globals.bias_a, {0, 0, 0, args.globals.chunk_idx});
+                warpgroup::load(args.scratch.bias_b, args.globals.bias_b, {0, 0, 0, args.globals.chunk_idx});
+            }
+        }
+        __device__ static inline void load(producer_load_args<layout> args) {
+            // Every load below must actually be issued, never skipped
+            if (warpgroup::warpid() == 0) warp::tma::expect(args.inputs_arrived, args.input);
+
+            // inputs_arrived needs one arrive() per producer warp (PRODUCER_BARRIER_
+            // ARRIVALS), independent of the byte-count gate above. expect() supplies warp
+            // 0's token; plain load_async doesn't touch this gate, so the other warps need
+            // an explicit arrive() even though they issue real loads below.
+            if (warpgroup::warpid() != 0 && laneid() == 0) arrive(args.inputs_arrived);
+
+            static_assert(layout::NUM_WORKERS % 4 == 0, "NUM_WORKERS must split evenly across the 4 producer warps");
+            constexpr int WORKERS_PER_WARP = layout::NUM_WORKERS / 4;
+            int pid = warpgroup::warpid(); // 0..3, which of the 4 producer warps this is
+            #pragma unroll
+            for (int i = 0; i < WORKERS_PER_WARP; i++) {
+                int w     = pid * WORKERS_PER_WARP + i;
+                int block = args.common.block_base + w;
+                int safe_block   = min(block, args.common.num_blocks - 1);
+                int safe_b_block = max(safe_block - 1, 0);
+                warp::tma::load_async(args.input.value_a[w], args.globals.value_a, {args.common.batch, 0, safe_block, args.globals.chunk_idx}, args.inputs_arrived);
+                warp::tma::load_async(args.input.score_a[w], args.globals.score_a, {args.common.batch, 0, safe_block, args.globals.chunk_idx}, args.inputs_arrived);
+                warp::tma::load_async(args.input.value_b[w], args.globals.value_b, {args.common.batch, 0, safe_b_block, args.globals.chunk_idx}, args.inputs_arrived);
+                warp::tma::load_async(args.input.score_b[w], args.globals.score_b, {args.common.batch, 0, safe_b_block, args.globals.chunk_idx}, args.inputs_arrived);
+            }
+        }
+    };
+
+    struct consumer {
+        __device__ static inline void setup(consumer_setup_args<layout> args) {
+            static_assert(NUM_CONSUMER_WARPS % 4 == 0, "consumer warp count must be a whole number of warpgroups");
+            // consumer_registers<NCWG>() fails to compile at NCWG=7 (480/7 truncates to a
+            // value that isn't a multiple of 8, required by setmaxnreg)
+            if constexpr (NUM_CONSUMER_WARPS/4 == 7) warpgroup::increase_registers<56>();
+            else                                     warpgroup::consumer_registers<NUM_CONSUMER_WARPS/4>();
+        }
+        // Softmax computed per-lane, per-channel 
+        __device__ static inline void compute(consumer_compute_args<layout> args) {
+            // groupid() picks the consumer warpgroup, warpid() the warp within it
+            int w     = warpgroup::groupid() * 4 + warpgroup::warpid();
+            int block = args.common.block_base + w;
+            if (block >= args.common.num_blocks) {
+                if (laneid() == 0) arrive(args.inputs_finished);
+                return;
+            }
+            bool has_b = block > 0;
+
+            constexpr int LANE_CHANNELS = layout::consumer_state::LANE_CHANNELS;
+            int lane = laneid();
+            int c0   = lane * LANE_CHANNELS; // first channel this lane owns, local to this chunk's tile
+
+            #pragma unroll
+            for (int c = 0; c < LANE_CHANNELS; c++) {
+                int ch = c0 + c;
+
+                // pass 1: za[p] = score_a[p] + bias_a[p] (and zb, if this isn't block 0).
+                float za[M], zb[M];
+                float mx = -INFINITY;
+                #pragma unroll
+                for (int p = 0; p < M; p++) {
+                    za[p] = float(args.input.score_a[w][{p, ch}]) + __bfloat162float(args.scratch.bias_a[{p, ch}]);
+                    mx = max(mx, za[p]);
+                }
+                if (has_b) {
+                    #pragma unroll
+                    for (int p = 0; p < M; p++) {
+                        zb[p] = float(args.input.score_b[w][{p, ch}]) + __bfloat162float(args.scratch.bias_b[{p, ch}]);
+                        mx = max(mx, zb[p]);
+                    }
+                }
+
+                // pass 2: shared softmax denominator; exp_za/exp_zb cached for pass 3.
+                float exp_za[M], exp_zb[M];
+                float denom = 0.f;
+                #pragma unroll
+                for (int p = 0; p < M; p++) {
+                    exp_za[p] = expf(za[p] - mx);
+                    denom += exp_za[p];
+                }
+                if (has_b) {
+                    #pragma unroll
+                    for (int p = 0; p < M; p++) {
+                        exp_zb[p] = expf(zb[p] - mx);
+                        denom += exp_zb[p];
+                    }
+                }
+
+                // pass 3: out_c = sum_p Sa[p]*value_a[p] (+ sum_p Sb[p]*value_b[p]).
+                float out = 0.f;
+                #pragma unroll
+                for (int p = 0; p < M; p++) {
+                    float Sa = exp_za[p] / denom;
+                    out += Sa * float(args.input.value_a[w][{p, ch}]);
+                }
+                if (has_b) {
+                    #pragma unroll
+                    for (int p = 0; p < M; p++) {
+                        float Sb = exp_zb[p] / denom;
+                        out += Sb * float(args.input.value_b[w][{p, ch}]);
+                    }
+                }
+
+                args.state.out_c[c] = out;
+            }
+
+            if (laneid() == 0) arrive(args.inputs_finished);
+        }
+        __device__ static inline void finish(consumer_finish_args<layout> args) {
+            int w     = warpgroup::groupid() * 4 + warpgroup::warpid();
+            int block = args.common.block_base + w;
+            if (block < args.common.num_blocks) {
+                constexpr int LANE_CHANNELS = layout::consumer_state::LANE_CHANNELS;
+                int lane = laneid();
+                int c0_local     = lane * LANE_CHANNELS;
+                int chunk_offset = args.globals.chunk_idx * C_CHUNK; // this chunk's base in the true C-wide output
+                #pragma unroll
+                for (int c = 0; c < LANE_CHANNELS; c++)
+                    args.globals.compressed[{args.common.batch, 0, block, chunk_offset + c0_local + c}] = __float2bfloat16(args.state.out_c[c]);
+            }
+            if (laneid() == 0) arrive(args.finish_finished);
+        }
+    };
+};
+
+// C_CHUNK=128, INPUT_PIPE_STAGES=1 is the best measured config on real H100 
+using csa_compression_kv      = compression_template</*C=*/512, /*C_CHUNK=*/128, /*M=*/4, /*NUM_WORKERS=*/28, /*INPUT_PIPE_STAGES=*/1>;
+using csa_compression_indexer = compression_template</*C=*/512, /*C_CHUNK=*/128, /*M=*/4, /*NUM_WORKERS=*/28, /*INPUT_PIPE_STAGES=*/1>;

--- a/kernels/csa/compression_h100/correctness.cu
+++ b/kernels/csa/compression_h100/correctness.cu
@@ -1,0 +1,151 @@
+// Correctness test for the CSA block compression kernel
+#include "compression_h100.cuh"
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <cmath>
+#include <algorithm>
+
+#define CudaCheckError() __cudaCheckError(__FILE__, __LINE__)
+inline void __cudaCheckError(const char *file, int line) {
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "cudaCheckError() failed at %s:%d : %s\n", file, line, cudaGetErrorString(err));
+        exit(-1);
+    }
+    err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "cudaCheckError() with sync failed at %s:%d : %s\n", file, line, cudaGetErrorString(err));
+        exit(-1);
+    }
+}
+
+static void read_floats(std::ifstream &infile, std::vector<float> &out) {
+    for (size_t i = 0; i < out.size(); i++) infile >> out[i];
+}
+static std::vector<bf16> to_bf16(const std::vector<float> &in) {
+    std::vector<bf16> out(in.size());
+    for (size_t i = 0; i < in.size(); i++) out[i] = __float2bfloat16(in[i]);
+    return out;
+}
+// gentests.py already rounds these to fp8e4m3-representable values, so this cast is exact.
+static std::vector<fp8e4m3> to_fp8e4m3(const std::vector<float> &in) {
+    std::vector<fp8e4m3> out(in.size());
+    for (size_t i = 0; i < in.size(); i++) out[i] = fp8e4m3(in[i]);
+    return out;
+}
+
+// Runs one (C, C_CHUNK, M) instantiation against a fixture read from `infile`. Read order
+// must match gentests.py's write order: value_a, value_b, score_a, score_b, bias_a,
+// bias_b, ref_compressed. Returns true if the kernel output is within tolerance.
+template<int C, int C_CHUNK, int M, int NUM_WORKERS=4, int PIPE=2>
+bool run_case(std::ifstream &infile, int B, int N) {
+    using ker    = compression_template<C, C_CHUNK, M, NUM_WORKERS, PIPE>;
+    using layout = typename ker::layout;
+    int num_blocks = N / M;
+
+    size_t value_elems = (size_t)B * N * C;
+    size_t bias_elems  = (size_t)M * C;
+    size_t out_elems   = (size_t)B * num_blocks * C;
+
+    std::vector<float> h_value_a(value_elems), h_value_b(value_elems);
+    std::vector<float> h_score_a(value_elems), h_score_b(value_elems);
+    std::vector<float> h_bias_a(bias_elems),   h_bias_b(bias_elems);
+    std::vector<float> h_ref(out_elems);
+
+    read_floats(infile, h_value_a);
+    read_floats(infile, h_value_b);
+    read_floats(infile, h_score_a);
+    read_floats(infile, h_score_b);
+    read_floats(infile, h_bias_a);
+    read_floats(infile, h_bias_b);
+    read_floats(infile, h_ref);
+
+    auto value_a_fp8 = to_fp8e4m3(h_value_a), value_b_fp8 = to_fp8e4m3(h_value_b);
+    auto score_a_fp8 = to_fp8e4m3(h_score_a), score_b_fp8 = to_fp8e4m3(h_score_b);
+    auto bias_a_bf   = to_bf16(h_bias_a),     bias_b_bf   = to_bf16(h_bias_b);
+
+    fp8e4m3 *d_value_a, *d_value_b, *d_score_a, *d_score_b;
+    bf16 *d_bias_a, *d_bias_b, *d_compressed;
+    cudaMalloc(&d_value_a, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_value_b, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_score_a, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_score_b, value_elems * sizeof(fp8e4m3));
+    cudaMalloc(&d_bias_a,  bias_elems  * sizeof(bf16));
+    cudaMalloc(&d_bias_b,  bias_elems  * sizeof(bf16));
+    cudaMalloc(&d_compressed, out_elems * sizeof(bf16));
+
+    cudaMemcpy(d_value_a, value_a_fp8.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_value_b, value_b_fp8.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_score_a, score_a_fp8.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_score_b, score_b_fp8.data(), value_elems * sizeof(fp8e4m3), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_bias_a,  bias_a_bf.data(),   bias_elems  * sizeof(bf16), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_bias_b,  bias_b_bf.data(),   bias_elems  * sizeof(bf16), cudaMemcpyHostToDevice);
+
+    // Compile-time-fixed gl dims take nullptr, runtime ones take a real size_t.
+    typename layout::block_global Va(d_value_a, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::block_global Vb(d_value_b, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::block_global Sa(d_score_a, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::block_global Sb(d_score_b, (size_t)B, nullptr, (size_t)N, nullptr);
+    typename layout::bias_global  Ba(d_bias_a,  nullptr,   nullptr, nullptr,   nullptr); // all 4 dims fixed
+    typename layout::bias_global  Bb(d_bias_b,  nullptr,   nullptr, nullptr,   nullptr);
+    typename layout::out_global   Og(d_compressed, (size_t)B, nullptr, (size_t)num_blocks, nullptr);
+
+    typename layout::globals globals = {Va, Vb, Sa, Sb, Ba, Bb, Og, /*chunk_idx=*/0}; // matches globals' declared field order
+
+    unsigned long mem_size = kittens::MAX_SHARED_MEMORY - 2000;
+    cudaFuncSetAttribute(prototype::lcf::kernel<ker>, cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    CudaCheckError();
+
+    constexpr int BLOCK_SIZE = prototype::detail::NUM_THREADS_v<ker>;
+    dim3 grid(132, 1, 1); // extra blocks (batch >= B) exit harmlessly on their first task_iter
+    // One launch per C_CHUNK-wide slice; each writes its own disjoint slice of `compressed`.
+    for (int chunk_idx = 0; chunk_idx < layout::NUM_CHUNKS; chunk_idx++) {
+        globals.chunk_idx = chunk_idx;
+        prototype::lcf::kernel<ker><<<grid, BLOCK_SIZE, mem_size>>>(globals);
+        CudaCheckError();
+    }
+
+    std::vector<bf16> out_bf(out_elems);
+    cudaMemcpy(out_bf.data(), d_compressed, out_elems * sizeof(bf16), cudaMemcpyDeviceToHost);
+
+    float total_diff = 0.f, max_diff = 0.f;
+    for (size_t i = 0; i < out_elems; i++) {
+        float val  = __bfloat162float(out_bf[i]);
+        float diff = std::abs(val - h_ref[i]);
+        total_diff += diff;
+        max_diff = std::max(max_diff, diff);
+    }
+    float avg_diff = total_diff / out_elems;
+    bool good = avg_diff < 0.02f && max_diff < 0.15f && !std::isnan(total_diff);
+    std::cout << "  [C=" << C << ", C_CHUNK=" << C_CHUNK << ", M=" << M << "] avg diff: " << avg_diff
+              << ", max diff: " << max_diff << " -> " << (good ? "PASS" : "FAIL") << std::endl;
+
+    cudaFree(d_value_a); cudaFree(d_value_b); cudaFree(d_score_a); cudaFree(d_score_b);
+    cudaFree(d_bias_a);  cudaFree(d_bias_b);  cudaFree(d_compressed);
+
+    return good;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        std::cerr << "usage: " << argv[0] << " <fixture.txt>  (generate one with gentests.py)\n";
+        return 1;
+    }
+    std::ifstream infile(argv[1]);
+    if (!infile) {
+        std::cerr << "could not open " << argv[1] << "\n";
+        return 1;
+    }
+
+    // Must match gentests.py, and NUM_WORKERS/PIPE must match csa_compression_kv/indexer's
+    // actual shipped values (compression_h100.cuh)
+    constexpr int B = 2, N = 316;
+
+    std::cout << "C=512, C_CHUNK=128, M=4, NUM_WORKERS=28, PIPE=1 (value/score fp8e4m3, bias/output bf16)\n";
+    bool good = run_case<512, /*C_CHUNK=*/128, /*M=*/4, /*NUM_WORKERS=*/28, /*PIPE=*/1>(infile, B, N);
+    std::cout << (good ? "PASSED\n" : "FAILED\n");
+    return good ? 0 : 1;
+}

--- a/kernels/csa/compression_h100/gentests.py
+++ b/kernels/csa/compression_h100/gentests.py
@@ -1,0 +1,89 @@
+import torch
+import numpy as np
+import sys
+
+print("Generating tests. This will take a moment.")
+
+torch.random.manual_seed(42)
+
+B = 2
+N = 316 
+
+TESTNAME = sys.argv[1] if len(sys.argv) > 1 else 'randn'
+
+
+def make_tensor(shape, dtype=torch.bfloat16):
+    if TESTNAME == 'ones':
+        base = torch.ones(shape, device='cuda')
+    elif TESTNAME == 'randn':
+        base = torch.randn(shape, device='cuda')
+    else:
+        print('Invalid test name')
+        sys.exit(1)
+    return base.to(dtype)
+
+
+def compression_reference(value_a, value_b, score_a, score_b, bias_a, bias_b, M):
+    """
+    Reference implementation of CSA. Matches correctness.cu's.
+    """
+    B, N, C = value_a.shape
+    num_blocks = N // M
+    out = torch.zeros((B, num_blocks, C), dtype=torch.float32, device=value_a.device)
+    for b in range(B):
+        for i in range(num_blocks):
+            za = score_a[b, i * M:(i + 1) * M, :].float() + bias_a.float()  # [M, C]
+            z_slices = [za]
+            value_slices = [value_a[b, i * M:(i + 1) * M, :].float()]
+            if i > 0:
+                zb = score_b[b, (i - 1) * M:i * M, :].float() + bias_b.float()  # [M, C]
+                z_slices.append(zb)
+                value_slices.append(value_b[b, (i - 1) * M:i * M, :].float())
+            z = torch.cat(z_slices, dim=0)      # [M, C] (i=0) or [2M, C]
+            val = torch.cat(value_slices, dim=0)
+            S = torch.softmax(z, dim=0)         # per-channel softmax down the rows
+            out[b, i, :] = (S * val).sum(dim=0)
+    return out
+
+
+def write_case(f, C, M):
+    value_a = make_tensor((B, N, C), dtype=torch.float8_e4m3fn)
+    value_b = make_tensor((B, N, C), dtype=torch.float8_e4m3fn)
+    score_a = make_tensor((B, N, C), dtype=torch.float8_e4m3fn)
+    score_b = make_tensor((B, N, C), dtype=torch.float8_e4m3fn)
+    bias_a = make_tensor((M, C))
+    bias_b = make_tensor((M, C))
+    ref = compression_reference(value_a, value_b, score_a, score_b, bias_a, bias_b, M)
+
+    # Sanity-check the reference: softmax weights should sum to 1 per channel per block.
+    num_blocks = N // M
+    for b in range(B):
+        for i in range(num_blocks):
+            za = score_a[b, i * M:(i + 1) * M, :].float() + bias_a.float()
+            z_slices = [za]
+            if i > 0:
+                zb = score_b[b, (i - 1) * M:i * M, :].float() + bias_b.float()
+                z_slices.append(zb)
+            z = torch.cat(z_slices, dim=0)
+            S = torch.softmax(z, dim=0)
+            assert torch.allclose(S.sum(dim=0), torch.ones_like(S.sum(dim=0)), atol=1e-3), \
+                f"softmax weights don't sum to 1 at b={b}, i={i}"
+
+    # Order here MUST match run_case<C,M>()'s read order in correctness.cu's
+    # standalone main(): value_a, value_b, score_a, score_b, bias_a, bias_b, ref_compressed.
+    for name, t in [('value_a', value_a), ('value_b', value_b),
+                     ('score_a', score_a), ('score_b', score_b),
+                     ('bias_a', bias_a), ('bias_b', bias_b),
+                     ('ref_compressed', ref)]:
+        arr = t.to(torch.float32).flatten().detach().cpu().numpy()
+        print(f"  Writing {name} ({arr.size} values)...")
+        np.savetxt(f, arr.reshape(1, -1), fmt='%.8g', delimiter=' ', newline=' ')
+
+
+fn = f'{TESTNAME}_compression_test.txt'
+with open(fn, 'w') as f:
+    # Real DeepSeek-V4 CSA paper values
+    print(f"C=512, M=4, B={B}, N={N}")
+    write_case(f, C=512, M=4)
+
+print(f"Wrote {fn}")


### PR DESCRIPTION
Hey guys! I'm a new guy around here and I've been really interested to contribute to this project.

As I've seen you guys were insterest in DS attention mechanism, I'm trying to implement one of the two DSV4 attention (described in https://arxiv.org/abs/2606.19348): the CSA (Compressed Sparse Attention) one on h100. The full architecture breaks down into 4 stages:

- Block compression 
- Lightning indexer + top-k selection 
- Sparse shared-KV MQA core attention 
- Grouped output projection

more concretely, with this PR i'm trying to implement the block compression mechanism.

here i'll post some key facts about my implementation:

- this kernel handles the real paper compression rate m=4 directly, with no padding: TK's tile primitives assume a 16-row floor, so this disables swizzling and computes the softmax per-lane/per-channel instead of using TK's cross-lane reduction primitives. lmk if this is too harmful for the compute (i'm still a beginner eheh.)
- C_CHUNK tiling works around TMA's 256-element unswizzled-tile-width cap
- I've used fp8e4m3 for value score tensors to avoid moving too much data
- NUM_WORKERS swept up to the hardware ceiling.

Here the benchmark results: 

Correctness: avg diff 0.00062, max diff 0.0077 with the pytorch impl.

Performance: best config (NUM_WORKERS=28, C_CHUNK=128, PIPE=1) ~410us/pass, ~1474 GB/s at a realistic long-context shape (B=8, N=32768, C=512, M=4).